### PR TITLE
Add configurable DNS zone names and NS delegation support

### DIFF
--- a/environments/production.tfvars
+++ b/environments/production.tfvars
@@ -1,1 +1,20 @@
 kubernetes_project_monthly_budget_amount = 5
+
+# NS delegation records for subdomain zones in the production public DNS zone.
+# After sandbox and non-production are first deployed, get nameservers from pt-corpus outputs:
+#   tofu output public_dns_zones
+#
+# public_dns_ns_delegations = [
+#   {
+#     managed_zone = "pneuma-osinfra-io"
+#     name         = "sb.pneuma.osinfra.io"
+#     ttl          = 300
+#     rrdatas      = [] # nameservers from sandbox pt-corpus output: public_dns_zones["pt-pneuma"].name_servers
+#   },
+#   {
+#     managed_zone = "pneuma-osinfra-io"
+#     name         = "nonprod.pneuma.osinfra.io"
+#     ttl          = 300
+#     rrdatas      = [] # nameservers from non-production pt-corpus output: public_dns_zones["pt-pneuma"].name_servers
+#   },
+# ]

--- a/locals.tofu
+++ b/locals.tofu
@@ -74,12 +74,20 @@ locals {
 
   # Teams with DNS Zones
   # Create DNS zone configurations for teams with Kubernetes clusters
-  # Extracts team name by removing prefix (e.g., pt-pneuma → pneuma)
+  # Uses public_dns_zone_name from team config when set; falls back to deriving from team name (e.g., pt-pneuma → pneuma)
   teams_with_dns_zones = {
     for team_key, team in module.helpers.teams :
     team_key => {
-      dns_name = module.helpers.env == "prod" ? "${replace(team_key, "/^[a-z]+-/", "")}.osinfra.io." : "${module.helpers.env}.${replace(team_key, "/^[a-z]+-/", "")}.osinfra.io."
-      name     = module.helpers.env == "prod" ? "${replace(team_key, "/^[a-z]+-/", "")}-osinfra-io" : "${module.helpers.env}-${replace(team_key, "/^[a-z]+-/", "")}-osinfra-io"
+      dns_name = lookup(team, "public_dns_zone_name", null) != null ? (
+        module.helpers.env == "prod" ? "${team.public_dns_zone_name}." : "${module.helpers.env}.${team.public_dns_zone_name}."
+        ) : (
+        module.helpers.env == "prod" ? "${replace(team_key, "/^[a-z]+-/", "")}.osinfra.io." : "${module.helpers.env}.${replace(team_key, "/^[a-z]+-/", "")}.osinfra.io."
+      )
+      name = lookup(team, "public_dns_zone_name", null) != null ? (
+        module.helpers.env == "prod" ? replace(team.public_dns_zone_name, ".", "-") : "${module.helpers.env}-${replace(team.public_dns_zone_name, ".", "-")}"
+        ) : (
+        module.helpers.env == "prod" ? "${replace(team_key, "/^[a-z]+-/", "")}-osinfra-io" : "${module.helpers.env}-${replace(team_key, "/^[a-z]+-/", "")}-osinfra-io"
+      )
     }
     if length(lookup(team, "google_kubernetes_engine_clusters", {})) > 0
   }

--- a/main.tofu
+++ b/main.tofu
@@ -288,6 +288,20 @@ resource "google_dns_record_set" "public" {
   type         = each.value.type
 }
 
+# DNS NS Delegation Record Set Resource
+# Adds NS records to a public zone to delegate subdomains (e.g., sb. and nonprod.) to their respective zones
+
+resource "google_dns_record_set" "public_ns_delegation" {
+  for_each = { for delegation in var.public_dns_ns_delegations : delegation.name => delegation }
+
+  managed_zone = each.value.managed_zone
+  name         = "${each.value.name}."
+  project      = module.project.id
+  rrdatas      = each.value.rrdatas
+  ttl          = each.value.ttl
+  type         = "NS"
+}
+
 # To avoid subject collisions, we are using a single provider per workload identity pool.
 # https://cloud.google.com/iam/docs/best-practices-for-using-workload-identity-federation#avoid-subject-collisions
 

--- a/variables.tofu
+++ b/variables.tofu
@@ -60,6 +60,17 @@ variable "project_monthly_budget_amount" {
   type        = number
 }
 
+variable "public_dns_ns_delegations" {
+  default     = []
+  description = "NS delegation records to add to public DNS zones for subdomain delegation (e.g., delegating sb. and nonprod. subzones from the production zone)"
+  type = list(object({
+    managed_zone = string
+    name         = string
+    rrdatas      = list(string)
+    ttl          = number
+  }))
+}
+
 variable "public_record_sets" {
   default     = []
   description = "Public DNS record sets"


### PR DESCRIPTION
Updates `teams_with_dns_zones` to use `public_dns_zone_name` from team config when set, falling back to the existing team-name derivation. Teams without `public_dns_zone_name` are unaffected.

Adds `public_dns_ns_delegations` variable and `google_dns_record_set.public_ns_delegation` resource so the production zone can delegate `sb.` and `nonprod.` subzones to their respective nameservers. A commented-out placeholder with fill-in instructions has been added to `environments/production.tfvars`.

**Deploy order:** pt-logos → pt-corpus → pt-pneuma

After sandbox and non-production are deployed, populate `public_dns_ns_delegations` in `production.tfvars` with the nameservers from `tofu output public_dns_zones`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DNS namespace delegation support. Users can now configure NS delegation records for subdomains, enabling delegation to respective managed DNS zones with customizable nameserver records and TTL settings across production and non-production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->