### PR TITLE
Add before-starting-task sync instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,6 +92,17 @@ git checkout main && git pull && git checkout -b <branch-name>
 - Use symlinks for shared configuration files to avoid duplication.
 - For OpenTofu-specific conventions (file structure, module pinning, resource patterns, workspace naming), refer to `.github/skills/opentofu.md`.
 
+### Before Starting Any Task
+
+Before making any changes, ensure all affected repositories are on `main` and in sync with `origin/main`:
+
+```bash
+git checkout main && git pull
+```
+
+- If a local branch already exists from a previous task, delete it before starting fresh
+- After a PR is merged, pull `main` and delete the local branch to stay clean
+
 ### Workspace Workflow Patterns
 
 - **Simultaneous multi-repo editing** - Apply standardization, updates, or patterns across all child module repos at once


### PR DESCRIPTION
Adds a `### Before Starting Any Task` section reminding Copilot to ensure all affected repos are on `main` and in sync with `origin/main` before beginning work, and to clean up local branches after PRs are merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidelines to establish consistent repository initialization practices and post-merge workflows.
  * Enhanced workspace workflow documentation with additional operational patterns and bulk operation procedures.
  * Added requirements for maintaining consistent development instructions across platform repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->