### PR TITLE
Fix MCSD service identity race condition with google_project_service_identity

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -38,6 +38,22 @@ provider "registry.opentofu.org/hashicorp/google" {
   ]
 }
 
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version = "7.21.0"
+  hashes = [
+    "h1:yvk3iIVqvUcmGClD72DmPaPguaUWt6KoYgwA0lvuePs=",
+    "zh:222c811bf1d5513a5299fc2defd7bdd08c44284edeea103cf70532837703c041",
+    "zh:2a3115bac4a098252df38285870471626d609a20c56b29f999ffe7137aaa387d",
+    "zh:5696ef380e8c1bc5a701aeb4e4db520b71a79e08acdacf130fef3abd16be8980",
+    "zh:703836b8e6fd0fe2ecdcb5557d7c29a0d2706a91c125065c8347b78d012d8f83",
+    "zh:7fa8312c6b52ee12304964fcf2f6adffd5320c7fc84cb3545a45e3795dc4e8a9",
+    "zh:8b3a090fa28ad2d192af45484ff92f532ec0b0da31fa2b3d05a8aed8e7e65f1d",
+    "zh:ae99e4fe32ff1f96039d1b6758d6f9f18affa0dc114772c072a2b21d15005f45",
+    "zh:c24d2f62bf0149817a0bf76023829171ecda335f4d6a379192367fa058219512",
+    "zh:c82a9b13b03ad418cb4672923cc3219e8ccc81e90e1a3928a5fbf0b0b05eb7a5",
+  ]
+}
+
 provider "registry.opentofu.org/hashicorp/random" {
   version = "3.7.2"
   hashes = [

--- a/main.tofu
+++ b/main.tofu
@@ -440,10 +440,20 @@ resource "google_project_iam_member" "kubernetes_project_owners" {
 # Required for MCS setup with Shared VPC
 # https://cloud.google.com/kubernetes-engine/docs/how-to/multi-cluster-services/setup#shared-vpc
 
+resource "google_project_service_identity" "multi_cluster_service_agent" {
+  provider = google-beta # Required for google_project_service_identity
+  for_each = { for team_key, team in local.teams_with_gke_clusters : team_key => team if team.has_gke_hub_host }
+
+  depends_on = [module.kubernetes_projects]
+
+  project = module.kubernetes_projects[each.key].id
+  service = "multiclusterservicediscovery.googleapis.com"
+}
+
 resource "google_project_iam_member" "multi_cluster_service_agent" {
   for_each = { for team_key, team in local.teams_with_gke_clusters : team_key => team if team.has_gke_hub_host }
 
-  member  = "serviceAccount:service-${module.kubernetes_projects[each.key].number}@gcp-sa-mcsd.iam.gserviceaccount.com"
+  member  = "serviceAccount:${google_project_service_identity.multi_cluster_service_agent[each.key].email}"
   project = module.project.id
   role    = "roles/multiclusterservicediscovery.serviceAgent"
 }

--- a/providers.tofu
+++ b/providers.tofu
@@ -75,6 +75,13 @@ terraform {
       source = "hashicorp/google"
     }
 
+    # Google Cloud Platform Beta Provider
+    # https://search.opentofu.org/provider/hashicorp/google-beta/latest/docs
+
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+
     # Random Provider
     # https://search.opentofu.org/provider/hashicorp/random/latest/docs
 


### PR DESCRIPTION
## Problem

Granting `roles/multiclusterservicediscovery.serviceAgent` fails on first apply for new Kubernetes projects:

```
Error: Service account service-<number>@gcp-sa-mcsd.iam.gserviceaccount.com does not exist.
```

The service account email was constructed directly from the project number, but GCP provisions the MCSD service agent asynchronously after `multiclusterservicediscovery.googleapis.com` is enabled. The service account doesn't exist yet when the IAM binding is applied — a re-run works because GCP has caught up.

## Fix

Add `google_project_service_identity` (`google-beta`) for `multiclusterservicediscovery.googleapis.com` on each Kubernetes project that needs it. This explicitly provisions the service agent and blocks until GCP confirms it is ready. The IAM member then uses `each.value.email` from the service identity resource instead of a constructed string.

Also adds `google-beta` to `required_providers`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Enabled Google Cloud Beta provider integration for enhanced multi-cluster service capabilities.
  * Updated multi-cluster service discovery configuration with dynamic service identity management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->