### PR TITLE
Add osinfra.io DNS zone with config-driven import

### DIFF
--- a/imports.tofu
+++ b/imports.tofu
@@ -2,6 +2,7 @@
 # https://opentofu.org/docs/language/import
 
 import {
-  id = "projects/${module.project.id}/managedZones/osinfra-io"
-  to = module.osinfra_io_dns.google_dns_managed_zone.this
+  for_each = toset(module.helpers.env == "prod" ? ["osinfra-io"] : [])
+  id       = "projects/${module.project.id}/managedZones/${each.key}"
+  to       = module.osinfra_io_dns[each.key].google_dns_managed_zone.this
 }

--- a/main.tofu
+++ b/main.tofu
@@ -130,15 +130,12 @@ module "project" {
 }
 
 module "osinfra_io_dns" {
-  source = "github.com/osinfra-io/opentofu-google-network//dns?ref=6efe0453acde9009d5a815487bde19573143307a" # v0.3.1
-
-  lifecycle {
-    enabled = module.helpers.env == "prod"
-  }
+  for_each = toset(module.helpers.env == "prod" ? ["osinfra-io"] : [])
+  source   = "github.com/osinfra-io/opentofu-google-network//dns?ref=6efe0453acde9009d5a815487bde19573143307a" # v0.3.1
 
   dns_name   = "osinfra.io."
   labels     = module.helpers.labels
-  name       = "osinfra-io"
+  name       = each.key
   project    = module.project.id
   visibility = "public"
 }

--- a/outputs.tofu
+++ b/outputs.tofu
@@ -17,12 +17,7 @@ output "kubernetes_projects" {
 
 output "osinfra_io_dns_zone" {
   description = "The osinfra.io public DNS zone (production only)"
-
-  value = module.helpers.env == "prod" ? {
-    dns_name     = module.osinfra_io_dns.dns_name
-    name         = module.osinfra_io_dns.name
-    name_servers = module.osinfra_io_dns.name_servers
-  } : null
+  value       = try(module.osinfra_io_dns["osinfra-io"], null)
 }
 
 output "project_id" {


### PR DESCRIPTION
## Problem

The `osinfra.io` root DNS zone exists in GCP but is not managed by OpenTofu. Any attempt to plan triggers an error because OpenTofu tries to delete/recreate the zone, but it cannot because it contains resource records.

## Fix

- Add `module "osinfra_io_dns"` using the existing dns module, gated to production only (`count = module.helpers.env == "prod" ? 1 : 0`)
- Add `imports.tofu` with a config-driven `import` block so OpenTofu adopts the existing zone rather than recreating it
- Add `osinfra_io_dns_zone` output for name server data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a public DNS zone for osinfra.io that is created only in production.
  * Enables dynamic cross-module referencing/import of the managed DNS zone so other parts of the stack can reference it per key when present.
  * Adds a production-only output exposing the DNS zone (returns null outside production).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->