### PR TITLE
Update opentofu-google-project to v0.6.1

### DIFF
--- a/main.tofu
+++ b/main.tofu
@@ -35,7 +35,7 @@ module "kubernetes_datadog" {
 
 module "kubernetes_projects" {
   for_each = local.teams_with_gke_clusters
-  source   = "github.com/osinfra-io/opentofu-google-project?ref=912e5f1e334e46f8048109e79ed4f30b32c036f1" # v0.6.0
+  source   = "github.com/osinfra-io/opentofu-google-project?ref=e8ed8d8fb82c6fbcf0b2489373d64808124646dc" # v0.6.1
 
   billing_account = var.project_billing_account
   deletion_policy = "DELETE"
@@ -98,7 +98,7 @@ module "private_dns" {
 # https://github.com/osinfra-io/opentofu-google-project
 
 module "project" {
-  source = "github.com/osinfra-io/opentofu-google-project?ref=912e5f1e334e46f8048109e79ed4f30b32c036f1" # v0.6.0
+  source = "github.com/osinfra-io/opentofu-google-project?ref=e8ed8d8fb82c6fbcf0b2489373d64808124646dc" # v0.6.1
 
   billing_account       = var.project_billing_account
   deletion_policy       = "DELETE"


### PR DESCRIPTION
Updates the opentofu-google-project module to v0.6.1 which fixes the null email race condition for the logging service identity during plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated opentofu-google-project module to v0.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->