### PR TITLE
Move public_dns state from count to for_each key

### DIFF
--- a/moved.tofu
+++ b/moved.tofu
@@ -1,0 +1,7 @@
+# Moved Blocks
+# https://opentofu.org/docs/language/moved
+
+moved {
+  from = module.public_dns[0]
+  to   = module.public_dns["pt-pneuma"]
+}


### PR DESCRIPTION
Adds a `moved` block to re-key `module.public_dns[0]` → `module.public_dns["pt-pneuma"]`, aligning existing state with the `for_each` configuration. This prevents the stale `[0]` entry from being destroyed on the next apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a moved block directive that allows users to define static mappings for block translations when reorganizing infrastructure code. This feature enables explicit path-based references from original block locations to destination locations, supporting infrastructure refactoring, block consolidation, and clear documentation of structural changes without affecting runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->