### PR TITLE
Point kubernetes projects CIS logging sink to corpus project

### DIFF
--- a/main.tofu
+++ b/main.tofu
@@ -35,7 +35,7 @@ module "kubernetes_datadog" {
 
 module "kubernetes_projects" {
   for_each = local.teams_with_gke_clusters
-  source   = "github.com/osinfra-io/opentofu-google-project?ref=138e2eb2c34c0ec1d8026fca9aa5d747dbd23964" # v0.6.4
+  source   = "github.com/osinfra-io/opentofu-google-project?ref=417573a22277a2bde85bfca61038e592a3b647f2" # v0.6.5
 
   billing_account                 = var.project_billing_account
   cis_2_2_logging_sink_project_id = module.project.id
@@ -99,7 +99,7 @@ module "private_dns" {
 # https://github.com/osinfra-io/opentofu-google-project
 
 module "project" {
-  source = "github.com/osinfra-io/opentofu-google-project?ref=138e2eb2c34c0ec1d8026fca9aa5d747dbd23964" # v0.6.4
+  source = "github.com/osinfra-io/opentofu-google-project?ref=417573a22277a2bde85bfca61038e592a3b647f2" # v0.6.5
 
   billing_account       = var.project_billing_account
   deletion_policy       = "DELETE"


### PR DESCRIPTION
Sets `cis_2_2_logging_sink_project_id = module.project.id` on all kubernetes projects so their CIS 2.2 logging sinks centralize to the corpus project for the respective environment, rather than each k8s project managing its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable logging-sink project identifier input to allow explicit routing of logs for compliance and auditing.

* **Chores**
  * Bumped referenced modules to newer patch releases for improved stability.
  * Minor formatting and alignment adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->