### PR TITLE
Make WIF ref conditions configurable for github-actions provider

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -34,7 +34,7 @@ locals {
           team_key   = team_key
         }
       ]
-    ]) : "${item.team_key}-${item.repository}" => item
+    ]) : item.repository => item
   }
 
   # osinfra.io DNS zone name and DNS name

--- a/moved.tofu
+++ b/moved.tofu
@@ -1,0 +1,27 @@
+# Moved Blocks
+# https://opentofu.org/docs/language/moved
+
+# Rename github_repositories map keys: drop redundant team_key prefix.
+# The repo keys from pt-logos already include the team prefix, so the old
+# "${team_key}-${repo_key}" construction was duplicating it. These blocks
+# can be removed once all environments have been applied.
+
+moved {
+  from = google_service_account_iam_member.github_actions["pt-corpus-pt-corpus"]
+  to   = google_service_account_iam_member.github_actions["pt-corpus"]
+}
+
+moved {
+  from = google_service_account_iam_member.github_actions["pt-logos-pt-logos"]
+  to   = google_service_account_iam_member.github_actions["pt-logos"]
+}
+
+moved {
+  from = google_service_account_iam_member.github_actions["pt-pneuma-pt-pneuma"]
+  to   = google_service_account_iam_member.github_actions["pt-pneuma"]
+}
+
+moved {
+  from = google_service_account_iam_member.github_actions["pt-pneuma-pt-pneuma-istio-test"]
+  to   = google_service_account_iam_member.github_actions["pt-pneuma-istio-test"]
+}


### PR DESCRIPTION
## Problem

The WIF `attribute_condition` for non-sandbox environments only allowed `refs/heads/main`, which rejected release workflows running on tag refs (e.g. `refs/tags/v0.3.7`).

## Solution

Replaces the hardcoded `assertion.ref=="refs/heads/main"` with a `github_actions_ref_conditions` local — a list of CEL expressions joined with `||` in the `attribute_condition`. This makes it easy to add or remove allowed refs.

**Allowed refs (non-sandbox):**
- `refs/heads/main` — push/merge workflows
- `refs/tags/*` — release workflows

## Testing

- Sandbox: condition unchanged (only requires `repository_owner_id`)
- Non-production / Production: condition now evaluates to `assertion.repository_owner_id=="104685378" && (assertion.ref == "refs/heads/main" || assertion.ref.startsWith("refs/tags/"))`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Consolidated GitHub Actions ref conditions for non-sandbox environments to uniformly allow main branch and tag refs for workload identity authentication.
* **Refactor**
  * Simplified repository key naming used in service-account IAM entries by removing redundant team-prefixes to align keys across resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->