### PR TITLE
Add GitHub Actions SA to registry-writers Google Group

### DIFF
--- a/main.tofu
+++ b/main.tofu
@@ -330,6 +330,21 @@ resource "google_cloud_identity_group_membership" "github_actions" {
   }
 }
 
+# Registry writers group membership - adds each team's GitHub Actions SA as a member of the
+# registry-writers group so release workflows can push images to Artifact Registry
+resource "google_cloud_identity_group_membership" "registry_writers" {
+  for_each = local.teams_with_artifact_registries
+
+  create_ignore_already_exists = true
+  group                        = module.helpers.teams[each.key].identity_groups["registry-writers"].name
+
+  preferred_member_key {
+    id = google_service_account.github_actions[each.key].email
+  }
+
+  roles { name = "MEMBER" }
+}
+
 # Compute Global Address Resource
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/compute_global_address
 


### PR DESCRIPTION
The `registry_writers` IAM binding only included the `registry-writers` Google Group. The GitHub Actions SA was not a member of that group, causing `artifactregistry.repositories.uploadArtifacts` denied errors on image push.

Follows the same pattern as GKE compute SAs joining `registry-readers` (via `google_cloud_identity_group_membership` in the GKE child module): adds a new `google_cloud_identity_group_membership.registry_writers` resource that makes each team's GitHub Actions SA a MEMBER of the team's `registry-writers` group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Actions service accounts are now automatically added as members of artifact registry writer groups for each team. Pre-existing memberships are handled gracefully to prevent configuration conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->