### PR TITLE
Enable Certificate Manager API on all Kubernetes projects

### DIFF
--- a/main.tofu
+++ b/main.tofu
@@ -141,6 +141,7 @@ module "kubernetes_projects" {
   services = concat(
     [
       "billingbudgets.googleapis.com",
+      "certificatemanager.googleapis.com",
       "cloudasset.googleapis.com",
       "cloudbilling.googleapis.com",
       "cloudkms.googleapis.com",


### PR DESCRIPTION
Adds `certificatemanager.googleapis.com` to the services list for all Kubernetes projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Google Cloud Certificate Manager service for Kubernetes projects, providing certificate management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->