### PR TITLE
Gate team_dns_subdomains on Kubernetes projects

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -94,6 +94,7 @@ locals {
   team_dns_subdomains = {
     for team_key, team in module.helpers.teams :
     team_key => lookup(team, "dns_subdomain", replace(team_key, "/^[a-z]+-/", ""))
+    if contains(keys(module.kubernetes_projects), team_key)
   }
 
   # Team subnets


### PR DESCRIPTION
DNS subdomain is only meaningful for teams with GKE clusters, since DNS zones are only created in pt-corpus for teams that have a Kubernetes project. This gates `team_dns_subdomains` on `module.kubernetes_projects` for consistency with `teams_with_artifact_registries`, which already uses the same condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DNS subdomains are now only provisioned for teams with active Kubernetes projects, eliminating unnecessary subdomain entries for teams without Kubernetes infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->