### PR TITLE
Remove pt-ekklesia workspace from logos_workspaces

### DIFF
--- a/helpers.tofu
+++ b/helpers.tofu
@@ -11,7 +11,6 @@ module "core_helpers" {
   logos_workspaces = [
     "pt-arche-main-production",
     "pt-corpus-main-production",
-    "pt-ekklesia-main-production",
     "pt-logos-main-production",
     "pt-pneuma-main-production",
     "pt-techne-main-production"


### PR DESCRIPTION
Remove `pt-ekklesia-main-production` from the `logos_workspaces` list in `helpers.tofu`. The pt-ekklesia repo has been removed from the platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a workspace from system configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->