### PR TITLE
Create master CIDR subnets with flow logs in regional workspace

### DIFF
--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -1,6 +1,17 @@
 # Google Subnet Module (osinfra.io)
 # https://github.com/osinfra-io/pt-arche-google-network
 
+module "google_network_master_subnets" {
+  source = "github.com/osinfra-io/pt-arche-google-network//regional?ref=68fb1e3db389fbeebde396ee61ba4ec3832123a7" # v0.3.5
+
+  for_each                 = local.regional_subnets
+  ip_cidr_range            = each.value.master_ipv4_cidr_block
+  name                     = "${each.key}-master"
+  network                  = local.main.vpc_name
+  private_ip_google_access = true
+  project                  = local.main.project_id
+}
+
 module "google_network_subnets" {
   source = "github.com/osinfra-io/pt-arche-google-network//regional?ref=68fb1e3db389fbeebde396ee61ba4ec3832123a7" # v0.3.5
 

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -58,6 +58,16 @@ resource "google_compute_subnetwork_iam_member" "cloud_services" {
   subnetwork = module.google_network_subnets[each.key].name
 }
 
+resource "google_compute_subnetwork_iam_member" "cloud_services_master" {
+  for_each = local.regional_subnets
+
+  member     = "serviceAccount:${each.value.service_project_number}@cloudservices.gserviceaccount.com"
+  project    = local.main.project_id
+  region     = module.core_helpers.region
+  role       = "roles/compute.networkUser"
+  subnetwork = module.google_network_master_subnets[each.key].name
+}
+
 resource "google_compute_subnetwork_iam_member" "container_engine" {
   for_each = local.regional_subnets
 
@@ -66,4 +76,14 @@ resource "google_compute_subnetwork_iam_member" "container_engine" {
   region     = module.core_helpers.region
   role       = "roles/compute.networkUser"
   subnetwork = module.google_network_subnets[each.key].name
+}
+
+resource "google_compute_subnetwork_iam_member" "container_engine_master" {
+  for_each = local.regional_subnets
+
+  member     = "serviceAccount:service-${each.value.service_project_number}@container-engine-robot.iam.gserviceaccount.com"
+  project    = local.main.project_id
+  region     = module.core_helpers.region
+  role       = "roles/compute.networkUser"
+  subnetwork = module.google_network_master_subnets[each.key].name
 }


### PR DESCRIPTION
## Summary

Creates a dedicated `/28` subnet for each GKE cluster's `master_ipv4_cidr_block` in the regional workspace. These subnets are consumed by pt-pneuma via the `private_endpoint_subnetwork` argument on the GKE module.

### Changes

- **`regional/main.tofu`** — Add `module "google_network_master_subnets"` using the existing `pt-arche-google-network//regional` source and same SHA as `google_network_subnets`
  - `for_each = local.regional_subnets` — one master subnet per cluster
  - `name = "${each.key}-master"` — e.g. `pt-pneuma-us-east1-b-master`
  - `ip_cidr_range = each.value.master_ipv4_cidr_block` — sourced from pt-logos subnet definitions
  - Flow logs are **enabled by default** in the network module (no special config needed)

### Notes

- `master_ipv4_cidr_block` already exists in `local.regional_subnets` — no upstream schema changes required
- Independent of the pt-arche-google-kubernetes-engine changes; can be merged on its own timeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Master subnets are now provisioned per region with private Google access enabled for improved regional network routing.
  * Corresponding service accounts have been granted the necessary network access to operate with these new master subnets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->