### PR TITLE
Rename google_projects module to google_project_teams

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -106,6 +106,7 @@ locals {
         "iamcredentials.googleapis.com",
         "monitoring.googleapis.com",
         "multiclusterservicediscovery.googleapis.com",
+        "pubsub.googleapis.com",
         "securitycenter.googleapis.com",
         "serviceusage.googleapis.com",
         "trafficdirector.googleapis.com"
@@ -179,6 +180,23 @@ locals {
   # Team labels
   # Maps team keys to labels, merging core_helpers labels with the team key
   team_labels = { for k, v in module.core_helpers.teams : k => merge(module.core_helpers.labels, { team = k }) }
+
+  # Team project services
+  # Constructs the list of services for each team project, sourced from pt-logos team configuration
+  team_project_services = {
+    for k, v in local.google_projects : k => [
+      "billingbudgets.googleapis.com",
+      "cloudasset.googleapis.com",
+      "cloudbilling.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+      "monitoring.googleapis.com",
+      "pubsub.googleapis.com",
+      "securitycenter.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+  }
 
   # Team subnets
   # Extract subnet configurations from cluster definitions in all teams, preserving team association.

--- a/main.tofu
+++ b/main.tofu
@@ -24,7 +24,7 @@ module "datadog_google_integration_datadog_projects" {
   is_cspm_enabled                    = true
   is_security_command_center_enabled = true
   labels                             = local.team_labels[each.value.team_key]
-  project                            = module.google_projects[each.key].id
+  project                            = module.google_project_teams[each.key].id
 }
 
 module "datadog_google_integration_kubernetes_projects" {
@@ -139,7 +139,7 @@ module "google_project_kubernetes" {
   services                        = local.kubernetes_project_services[each.key]
 }
 
-module "google_projects" {
+module "google_project_teams" {
   source = "github.com/osinfra-io/pt-arche-google-project?ref=8b86debb6614d96cb891b652754693a459e9efbb" # v0.6.10
 
   for_each                        = local.google_projects
@@ -151,7 +151,7 @@ module "google_projects" {
   labels                          = local.team_labels[each.value.team_key]
   monthly_budget_amount           = var.project_monthly_budget_amount
   prefix                          = each.value.team_key
-  services                        = each.value.services
+  services                        = local.team_project_services[each.key]
 }
 
 # Google Storage Bucket Module (osinfra.io)
@@ -522,7 +522,7 @@ resource "google_project_iam_member" "google_project_owners" {
   for_each = local.google_projects_with_service_accounts
 
   member  = "serviceAccount:${google_service_account.github_actions[each.value.team_key].email}"
-  project = module.google_projects[each.key].id
+  project = module.google_project_teams[each.key].id
   role    = "roles/owner"
 }
 

--- a/moved.tofu
+++ b/moved.tofu
@@ -1,0 +1,7 @@
+# Moved Blocks
+# https://opentofu.org/docs/language/moved
+
+moved {
+  from = module.google_projects
+  to   = module.google_project_teams
+}

--- a/outputs.tofu
+++ b/outputs.tofu
@@ -67,10 +67,10 @@ output "teams" {
       google_projects = {
         for description, project in team.google_projects :
         description => {
-          id       = module.google_projects["${team_key}-${description}"].id
+          id       = module.google_project_teams["${team_key}-${description}"].id
           services = project.services
         }
-        if contains(keys(module.google_projects), "${team_key}-${description}")
+        if contains(keys(module.google_project_teams), "${team_key}-${description}")
       }
 
       kubernetes_project = contains(keys(module.google_project_kubernetes), team_key) ? {


### PR DESCRIPTION
Renames the `google_projects` module to `google_project_teams` to better communicate that these are additional GCP projects a team may want outside the Kubernetes project.

## Changes

- Rename `module "google_projects"` → `module "google_project_teams"` in `main.tofu` and update all references
- Add `moved.tofu` with a `moved` block so OpenTofu migrates existing state without destroying and recreating resources
- Add `team_project_services` local in `locals.tofu` mirroring `kubernetes_project_services` but without GKE Hub services (`multiclusterservicediscovery.googleapis.com`, `trafficdirector.googleapis.com`, `gkehub.googleapis.com`, `multiclusteringress.googleapis.com`)
- Update `outputs.tofu` references accordingly