### PR TITLE
Simplify Google Cloud project naming for teams

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -177,6 +177,18 @@ locals {
   # Maps team keys to labels, merging core_helpers labels with the team key
   team_labels = { for k, v in module.core_helpers.teams : k => merge(module.core_helpers.labels, { team = k }) }
 
+  # Team project descriptions
+  # Derives the description component of the team key for GCP project naming (e.g., "pt-kryptos" → "kryptos")
+  team_project_descriptions = {
+    for k, _ in local.google_projects : k => split("-", k)[1]
+  }
+
+  # Team project prefixes
+  # Derives the prefix component of the team key for GCP project naming (e.g., "pt-kryptos" → "pt")
+  team_project_prefixes = {
+    for k, _ in local.google_projects : k => split("-", k)[0]
+  }
+
   # Team project services
   # Constructs the list of services for each team project, sourced from pt-logos team configuration
   team_project_services = {

--- a/locals.tofu
+++ b/locals.tofu
@@ -60,19 +60,15 @@ locals {
   }
 
   # Google Projects
-  # Flatten team google_projects into a map keyed by "{team_key}-{description}" for project creation
+  # Teams that have opted in to a Google Cloud project
   google_projects = {
-    for item in flatten([
-      for team_key, team in module.core_helpers.teams : [
-        for description, project in team.google_projects : {
-          description    = description
-          enable_datadog = project.enable_datadog
-          services       = project.services
-          team_key       = team_key
-        }
-      ]
-      if team.enable_workflows
-    ]) : "${item.team_key}-${item.description}" => item
+    for team_key, team in module.core_helpers.teams :
+    team_key => {
+      enable_datadog = team.google_project_enable_datadog
+      services       = team.google_project_services
+      team_key       = team_key
+    }
+    if team.enable_workflows && team.enable_google_project
   }
 
   # Google Projects with Datadog enabled
@@ -86,7 +82,7 @@ locals {
   # Google projects with service accounts
   # Subset of google_projects filtered to those whose team has a corresponding service account
   google_projects_with_service_accounts = {
-    for k, v in local.google_projects : k => v if contains(keys(local.service_accounts), v.team_key)
+    for k, v in local.google_projects : k => v if contains(keys(local.service_accounts), k)
   }
 
   # Kubernetes project services

--- a/locals.tofu
+++ b/locals.tofu
@@ -190,20 +190,24 @@ locals {
   }
 
   # Team project services
-  # Constructs the list of services for each team project, sourced from pt-logos team configuration
+  # Constructs the list of services for each team project, merging the required baseline with per-team
+  # additional services sourced from pt-logos team configuration
   team_project_services = {
-    for k, v in local.google_projects : k => [
-      "billingbudgets.googleapis.com",
-      "cloudasset.googleapis.com",
-      "cloudbilling.googleapis.com",
-      "cloudresourcemanager.googleapis.com",
-      "compute.googleapis.com",
-      "iam.googleapis.com",
-      "monitoring.googleapis.com",
-      "pubsub.googleapis.com",
-      "securitycenter.googleapis.com",
-      "serviceusage.googleapis.com",
-    ]
+    for k, v in local.google_projects : k => concat(
+      [
+        "billingbudgets.googleapis.com",
+        "cloudasset.googleapis.com",
+        "cloudbilling.googleapis.com",
+        "cloudresourcemanager.googleapis.com",
+        "compute.googleapis.com",
+        "iam.googleapis.com",
+        "monitoring.googleapis.com",
+        "pubsub.googleapis.com",
+        "securitycenter.googleapis.com",
+        "serviceusage.googleapis.com",
+      ],
+      v.services
+    )
   }
 
   # Team subnets

--- a/locals.tofu
+++ b/locals.tofu
@@ -178,9 +178,9 @@ locals {
   team_labels = { for k, v in module.core_helpers.teams : k => merge(module.core_helpers.labels, { team = k }) }
 
   # Team project descriptions
-  # Derives the description component of the team key for GCP project naming (e.g., "pt-kryptos" → "kryptos")
+  # Derives the description component of the team key for GCP project naming (e.g., "pt-my-team" → "my-team")
   team_project_descriptions = {
-    for k, _ in local.google_projects : k => split("-", k)[1]
+    for k, _ in local.google_projects : k => replace(k, "/^[a-z]+-/", "")
   }
 
   # Team project prefixes

--- a/main.tofu
+++ b/main.tofu
@@ -146,11 +146,11 @@ module "google_project_teams" {
   billing_account                 = var.project_billing_account
   cis_2_2_logging_sink_project_id = module.google_project.id
   deletion_policy                 = "DELETE"
-  description                     = each.value.description
+  description                     = replace(each.value.team_key, "/^[a-z]+-/", "")
   folder_id                       = module.core_helpers.teams[each.value.team_key].environments[local.environment_key]
   labels                          = local.team_labels[each.value.team_key]
   monthly_budget_amount           = var.project_monthly_budget_amount
-  prefix                          = each.value.team_key
+  prefix                          = split("-", each.value.team_key)[0]
   services                        = local.team_project_services[each.key]
 }
 

--- a/main.tofu
+++ b/main.tofu
@@ -146,11 +146,11 @@ module "google_project_teams" {
   billing_account                 = var.project_billing_account
   cis_2_2_logging_sink_project_id = module.google_project.id
   deletion_policy                 = "DELETE"
-  description                     = replace(each.key, "/^[a-z]+-/", "")
+  description                     = local.team_project_descriptions[each.key]
   folder_id                       = module.core_helpers.teams[each.key].environments[local.environment_key]
   labels                          = local.team_labels[each.key]
   monthly_budget_amount           = var.project_monthly_budget_amount
-  prefix                          = split("-", each.key)[0]
+  prefix                          = local.team_project_prefixes[each.key]
   services                        = local.team_project_services[each.key]
 }
 

--- a/main.tofu
+++ b/main.tofu
@@ -146,11 +146,11 @@ module "google_project_teams" {
   billing_account                 = var.project_billing_account
   cis_2_2_logging_sink_project_id = module.google_project.id
   deletion_policy                 = "DELETE"
-  description                     = replace(each.value.team_key, "/^[a-z]+-/", "")
-  folder_id                       = module.core_helpers.teams[each.value.team_key].environments[local.environment_key]
-  labels                          = local.team_labels[each.value.team_key]
+  description                     = replace(each.key, "/^[a-z]+-/", "")
+  folder_id                       = module.core_helpers.teams[each.key].environments[local.environment_key]
+  labels                          = local.team_labels[each.key]
   monthly_budget_amount           = var.project_monthly_budget_amount
-  prefix                          = split("-", each.value.team_key)[0]
+  prefix                          = split("-", each.key)[0]
   services                        = local.team_project_services[each.key]
 }
 

--- a/outputs.tofu
+++ b/outputs.tofu
@@ -64,14 +64,9 @@ output "teams" {
   value = {
     for team_key, team in module.core_helpers.teams :
     team_key => merge(team, {
-      google_projects = {
-        for description, project in team.google_projects :
-        description => {
-          id       = module.google_project_teams["${team_key}-${description}"].id
-          services = project.services
-        }
-        if contains(keys(module.google_project_teams), "${team_key}-${description}")
-      }
+      google_project = contains(keys(module.google_project_teams), team_key) ? {
+        id = module.google_project_teams[team_key].id
+      } : null
 
       kubernetes_project = contains(keys(module.google_project_kubernetes), team_key) ? {
         environment = module.core_helpers.env


### PR DESCRIPTION
## Summary

Derive team GCP project IDs from the team key (e.g. `pt-kryptos-tfXX-nonprod`) rather than the user-chosen `google_projects` map key. This matches the pattern used for the corpus-own project and fixes a 30-char project name limit violation.

### Changes

- **`main.tofu`** — In `module.google_project_teams`:
  - `description` now uses `replace(each.value.team_key, "/^[a-z]+-/", "")` (e.g. `kryptos`)
  - `prefix` now uses `split("-", each.value.team_key)[0]` (e.g. `pt`)

### Before / After

| Team key | Map key | Before | After |
|---|---|---|---|
| `pt-kryptos` | `openbao` | `pt-kryptos-openbao-tfXX-nonprod` (31 chars ❌) | `pt-kryptos-tfXX-nonprod` ✅ |
| `pt-kryptos` | `default` | `pt-kryptos-default-tfXX-nonprod` | `pt-kryptos-tfXX-nonprod` ✅ |
| `pt-techne` | `testing` | `pt-techne-testing-tfXX-nonprod` | `pt-techne-tfXX-nonprod` |

### ⚠️ Breaking change for pt-techne

The existing `pt-techne-testing` project will be **destroyed and recreated** with a new name (`pt-techne-tfXX-nonprod`) on next apply. The project has `services = []` and `deletion_policy = "DELETE"` so this is safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Derived project descriptions and prefixes from consolidated team keys.
  * Moved project flags and service lists to be per-team, removing multiple per-description projects.
  * Rewired folder assignment, labels, and project naming to use the new team-key mapping.
  * Simplified outputs to expose a single project reference per team (removed per-description project entries).
  * Updated service-account detection to align with the new per-team mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->