### PR TITLE
Add project-type=kubernetes label to kubernetes projects

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -53,6 +53,13 @@ locals {
     ]) : item.repository => item
   }
 
+  # GKE teams for pneuma access
+  # All GKE teams (excluding pt-pneuma itself) whose kubernetes projects pt-pneuma must access
+  # to provision and manage GKE clusters on their behalf
+  gke_teams_for_pneuma_access = {
+    for k, v in local.teams_with_gke_clusters : k => v if k != "pt-pneuma"
+  }
+
   # GKE teams with service accounts
   # Subset of teams_with_gke_clusters filtered to those with a corresponding service account
   gke_teams_with_service_accounts = {

--- a/main.tofu
+++ b/main.tofu
@@ -133,7 +133,7 @@ module "google_project_kubernetes" {
   deletion_policy                 = "DELETE"
   description                     = "k8s"
   folder_id                       = module.core_helpers.teams[each.key].environments[local.environment_key]
-  labels                          = local.team_labels[each.key]
+  labels                          = merge(local.team_labels[each.key], { project_type = "kubernetes" })
   monthly_budget_amount           = var.kubernetes_project_monthly_budget_amount
   prefix                          = each.key
   services                        = local.kubernetes_project_services[each.key]

--- a/main.tofu
+++ b/main.tofu
@@ -133,7 +133,7 @@ module "google_project_kubernetes" {
   deletion_policy                 = "DELETE"
   description                     = "k8s"
   folder_id                       = module.core_helpers.teams[each.key].environments[local.environment_key]
-  labels                          = merge(local.team_labels[each.key], { project_type = "kubernetes" })
+  labels                          = merge(local.team_labels[each.key], { "project-type" = "kubernetes" })
   monthly_budget_amount           = var.kubernetes_project_monthly_budget_amount
   prefix                          = each.key
   services                        = local.kubernetes_project_services[each.key]

--- a/main.tofu
+++ b/main.tofu
@@ -537,6 +537,18 @@ resource "google_project_iam_member" "kubernetes_project_owners" {
   role    = "roles/owner"
 }
 
+# Kubernetes Project Pneuma Owners
+# Grant the pt-pneuma service account owner role on all other teams' kubernetes projects
+# so pt-pneuma can provision and manage GKE clusters on behalf of all teams.
+
+resource "google_project_iam_member" "kubernetes_project_pneuma_owners" {
+  for_each = local.gke_teams_for_pneuma_access
+
+  member  = "serviceAccount:${google_service_account.github_actions["pt-pneuma"].email}"
+  project = module.google_project_kubernetes[each.key].id
+  role    = "roles/owner"
+}
+
 resource "google_project_iam_member" "multi_cluster_service_agents" {
   for_each = local.teams_with_gke_hub_host
 


### PR DESCRIPTION
Both kubernetes and team projects previously shared identical GCP labels (`labels.team` + `labels.repository`), making it non-deterministic when consumers (pt-pneuma) filter projects by label — either project could be returned as `projects[0]`.

**Changes:**

1. Add a `project-type = "kubernetes"` label to `module "google_project_kubernetes"` so the kubernetes project has a unique label that consumers can filter on.

2. Add `google_project_iam_member.kubernetes_project_pneuma_owners` — grants the pt-pneuma service account `roles/owner` on all **other** teams' kubernetes projects. pt-pneuma provisions GKE clusters on behalf of all teams, so its service account needs access to every team's kubernetes project, not just its own.

Both changes are in-place updates — no project recreation required.

**Paired with:** osinfra-io/pt-pneuma#85 (updates `data.google_projects` filters to include `labels.project-type:kubernetes`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Kubernetes projects with a "project-type: kubernetes" label.
  * Granted owner-level access for the pt-pneuma CI service account to relevant Kubernetes projects to enable automated workflows.
  * Introduced a filtered team access view that excludes the pt-pneuma team for targeted project access management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->