### PR TITLE
Rename kubernetes project to platform-managed project

### DIFF
--- a/backend.tofu
+++ b/backend.tofu
@@ -1,1 +1,13 @@
-shared/backend.tofu
+# Backend Configuration
+# https://opentofu.org/docs/language/settings/backends/configuration
+
+terraform {
+  # Google Cloud Storage
+  # https://opentofu.org/docs/language/settings/backends/gcs
+
+  backend "gcs" {
+    bucket             = var.state_bucket
+    kms_encryption_key = var.state_kms_encryption_key
+    prefix             = var.state_prefix
+  }
+}

--- a/helpers.tofu
+++ b/helpers.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=1024a5446b33be60bba2d52897ba4f487cb469ed" # v0.2.3
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
 
   cost_center         = "x001"
   data_classification = "public"

--- a/locals.tofu
+++ b/locals.tofu
@@ -177,7 +177,7 @@ locals {
   team_dns_subdomains = {
     for team_key, team in module.core_helpers.teams :
     team_key => team.dns_subdomain != null ? team.dns_subdomain : replace(team_key, "/^[a-z]+-/", "")
-    if length(team.google_kubernetes_engine_clusters.locations) > 0
+    if length(team.platform_managed_project.kubernetes_engine_locations) > 0
   }
 
   # Team labels
@@ -211,7 +211,7 @@ locals {
   # Region is extracted from the location key by stripping the zone suffix (e.g., us-east1-b → us-east1).
   team_subnets = merge([
     for team_key, team in module.core_helpers.teams : {
-      for location, cluster in team.google_kubernetes_engine_clusters.locations :
+      for location, cluster in team.platform_managed_project.kubernetes_engine_locations :
       "${team_key}-${location}" => merge(cluster.subnet, {
         region   = regex("^(us-[a-z]+[0-9]+)-[a-z]$", location)[0]
         team_key = team_key
@@ -246,7 +246,7 @@ locals {
       dns_name = module.core_helpers.env == "prod" ? "${local.team_dns_subdomains[team_key]}.osinfra.io." : "${local.team_dns_subdomains[team_key]}.${module.core_helpers.env}.osinfra.io."
       name     = module.core_helpers.env == "prod" ? "${local.team_dns_subdomains[team_key]}-osinfra-io" : "${local.team_dns_subdomains[team_key]}-${module.core_helpers.env}-osinfra-io"
     }
-    if length(team.google_kubernetes_engine_clusters.locations) > 0
+    if length(team.platform_managed_project.kubernetes_engine_locations) > 0
   }
 
   # Teams with platform-managed projects
@@ -256,11 +256,11 @@ locals {
     team_key => merge(team, {
       # Check if any cluster in this team has enable_gke_hub_host = true
       has_gke_hub_host = anytrue([
-        for location, cluster in team.google_kubernetes_engine_clusters.locations :
+        for location, cluster in team.platform_managed_project.kubernetes_engine_locations :
         lookup(cluster, "enable_gke_hub_host", false)
       ])
     })
-    if length(team.google_kubernetes_engine_clusters.locations) > 0
+    if team.has_platform_managed_project
   }
 
   # Teams with GKE Hub Host
@@ -276,7 +276,7 @@ locals {
   teams_with_platform_managed_datadog = {
     for team_key, team in local.teams_with_platform_managed_projects :
     team_key => team
-    if team.enable_kubernetes_datadog
+    if team.enable_platform_managed_datadog
   }
 
   # VPC Service Projects

--- a/locals.tofu
+++ b/locals.tofu
@@ -54,16 +54,25 @@ locals {
   }
 
   # GKE teams for pneuma access
-  # All platform-managed teams (excluding pt-pneuma itself) whose platform-managed projects pt-pneuma must access
-  # to provision and manage GKE clusters on their behalf
+  # Platform-managed teams with GKE clusters (excluding pt-pneuma itself) whose platform-managed projects
+  # pt-pneuma must access to provision and manage GKE clusters on their behalf
   gke_teams_for_pneuma_access = {
-    for k, v in local.teams_with_platform_managed_projects : k => v if k != "pt-pneuma"
+    for k, v in local.teams_with_platform_managed_projects : k => v
+    if k != "pt-pneuma" && length(v.platform_managed_project.kubernetes_engine_locations) > 0
   }
 
   # GKE teams with service accounts
-  # Subset of teams_with_platform_managed_projects filtered to those with a corresponding service account
+  # Subset of teams_with_platform_managed_projects filtered to those with GKE clusters and a corresponding service account
   gke_teams_with_service_accounts = {
-    for k, v in local.teams_with_platform_managed_projects : k => v if contains(keys(local.service_accounts), k)
+    for k, v in local.teams_with_platform_managed_projects : k => v
+    if contains(keys(local.service_accounts), k) && length(v.platform_managed_project.kubernetes_engine_locations) > 0
+  }
+
+  # Platform-managed teams with service accounts
+  # All teams with platform-managed projects (GKE or data services) that also have a service account
+  platform_managed_teams_with_service_accounts = {
+    for k, v in local.teams_with_platform_managed_projects : k => v
+    if contains(keys(local.service_accounts), k)
   }
 
   # Google Projects

--- a/locals.tofu
+++ b/locals.tofu
@@ -19,9 +19,9 @@ locals {
   # Resolves the for_each for the google_project_datadog module: enabled only when var.datadog_enable is true
   datadog_google_project_for_each = var.datadog_enable ? local.google_projects_with_datadog : {}
 
-  # Datadog Kubernetes for_each
-  # Resolves the for_each for the kubernetes_datadog module: enabled only when var.datadog_enable is true
-  datadog_kubernetes_for_each = var.datadog_enable ? local.teams_with_kubernetes_datadog : {}
+  # Datadog platform-managed for_each
+  # Resolves the for_each for the platform_managed_datadog module: enabled only when var.datadog_enable is true
+  datadog_platform_managed_for_each = var.datadog_enable ? local.teams_with_platform_managed_datadog : {}
 
   # Enable Cloud Cost Management only in production
   enable_cloud_cost_management = module.core_helpers.env == "prod"
@@ -54,16 +54,16 @@ locals {
   }
 
   # GKE teams for pneuma access
-  # All GKE teams (excluding pt-pneuma itself) whose kubernetes projects pt-pneuma must access
+  # All platform-managed teams (excluding pt-pneuma itself) whose platform-managed projects pt-pneuma must access
   # to provision and manage GKE clusters on their behalf
   gke_teams_for_pneuma_access = {
-    for k, v in local.teams_with_gke_clusters : k => v if k != "pt-pneuma"
+    for k, v in local.teams_with_platform_managed_projects : k => v if k != "pt-pneuma"
   }
 
   # GKE teams with service accounts
-  # Subset of teams_with_gke_clusters filtered to those with a corresponding service account
+  # Subset of teams_with_platform_managed_projects filtered to those with a corresponding service account
   gke_teams_with_service_accounts = {
-    for k, v in local.teams_with_gke_clusters : k => v if contains(keys(local.service_accounts), k)
+    for k, v in local.teams_with_platform_managed_projects : k => v if contains(keys(local.service_accounts), k)
   }
 
   # Google Projects
@@ -92,10 +92,10 @@ locals {
     for k, v in local.google_projects : k => v if contains(keys(local.service_accounts), k)
   }
 
-  # Kubernetes project services
-  # Constructs the list of services for each Kubernetes project, conditionally appending GKE Hub services
-  kubernetes_project_services = {
-    for k, v in local.teams_with_gke_clusters : k => concat(
+  # Platform-managed project services
+  # Constructs the list of services for each platform-managed project, conditionally appending GKE Hub services
+  platform_managed_project_services = {
+    for k, v in local.teams_with_platform_managed_projects : k => concat(
       [
         "billingbudgets.googleapis.com",
         "certificatemanager.googleapis.com",
@@ -149,13 +149,13 @@ locals {
   private_dns_zone_name = module.core_helpers.env == "prod" ? "gcp.priv.osinfra.io." : "gcp.priv.${module.core_helpers.env}.osinfra.io."
 
   # Regional subnets
-  # Organize subnets by region for regional deployments, enriched with Kubernetes project numbers
+  # Organize subnets by region for regional deployments, enriched with platform-managed project numbers
   regional_subnets = {
     for region in distinct([for k, v in local.team_subnets : v.region]) :
     region => {
       for subnet_key, subnet in local.team_subnets :
       subnet_key => merge(subnet, {
-        service_project_number = module.google_project_kubernetes[subnet.team_key].number
+        service_project_number = module.google_project_platform_managed[subnet.team_key].number
       })
       if subnet.region == region
     }
@@ -183,18 +183,6 @@ locals {
   # Team labels
   # Maps team keys to labels, merging core_helpers labels with the team key
   team_labels = { for k, v in module.core_helpers.teams : k => merge(module.core_helpers.labels, { team = k }) }
-
-  # Team project descriptions
-  # Derives the description component of the team key for GCP project naming (e.g., "pt-my-team" → "my-team")
-  team_project_descriptions = {
-    for k, _ in local.google_projects : k => replace(k, "/^[a-z]+-/", "")
-  }
-
-  # Team project prefixes
-  # Derives the prefix component of the team key for GCP project naming (e.g., "pt-kryptos" → "pt")
-  team_project_prefixes = {
-    for k, _ in local.google_projects : k => split("-", k)[0]
-  }
 
   # Team project services
   # Constructs the list of services for each team project, merging the required baseline with per-team
@@ -238,7 +226,7 @@ locals {
     team_key => {
       registry_readers = [
         "group:${team.identity_groups["registry-readers"].email}",
-        "serviceAccount:${module.google_project_kubernetes[team_key].number}-compute@developer.gserviceaccount.com"
+        "serviceAccount:${module.google_project_platform_managed[team_key].number}-compute@developer.gserviceaccount.com"
       ]
       registry_writers = [
         "group:${team.identity_groups["registry-writers"].email}"
@@ -261,9 +249,9 @@ locals {
     if length(team.google_kubernetes_engine_clusters.locations) > 0
   }
 
-  # Teams with GKE Clusters
-  # Identify teams that need Kubernetes projects
-  teams_with_gke_clusters = {
+  # Teams with platform-managed projects
+  # Identify teams that need platform-managed projects (GKE clusters, data services, etc.)
+  teams_with_platform_managed_projects = {
     for team_key, team in module.core_helpers.teams :
     team_key => merge(team, {
       # Check if any cluster in this team has enable_gke_hub_host = true
@@ -276,28 +264,28 @@ locals {
   }
 
   # Teams with GKE Hub Host
-  # Subset of teams_with_gke_clusters where the team has a GKE Hub host cluster
+  # Subset of teams_with_platform_managed_projects where the team has a GKE Hub host cluster
   teams_with_gke_hub_host = {
-    for team_key, team in local.teams_with_gke_clusters :
+    for team_key, team in local.teams_with_platform_managed_projects :
     team_key => team
     if team.has_gke_hub_host
   }
 
-  # Teams with Kubernetes Datadog enabled
-  # Subset of teams_with_gke_clusters where the team has opted in to Datadog integration
-  teams_with_kubernetes_datadog = {
-    for team_key, team in local.teams_with_gke_clusters :
+  # Teams with platform-managed Datadog enabled
+  # Subset of teams_with_platform_managed_projects where the team has opted in to Datadog integration
+  teams_with_platform_managed_datadog = {
+    for team_key, team in local.teams_with_platform_managed_projects :
     team_key => team
     if team.enable_kubernetes_datadog
   }
 
   # VPC Service Projects
-  # Automatically include all Kubernetes projects as VPC service projects
-  # Merges manually configured service projects with Kubernetes projects
+  # Automatically include all platform-managed projects as VPC service projects
+  # Merges manually configured service projects with platform-managed projects
   # Keys must be statically known at plan time, so team_key is used instead of project.id
   vpc_service_projects = merge(
     {
-      for team_key, project in module.google_project_kubernetes :
+      for team_key, project in module.google_project_platform_managed :
       team_key => {
         id     = project.id
         number = project.number
@@ -312,11 +300,11 @@ locals {
     }
   )
 
-  # VPC Service Projects for Kubernetes
-  # Only Kubernetes projects that need GKE-specific IAM permissions
+  # VPC Service Projects for platform-managed
+  # Only platform-managed projects that need GKE-specific IAM permissions
   # Keys must be statically known at plan time, so team_key is used instead of project.id
-  vpc_service_projects_kubernetes = {
-    for team_key, project in module.google_project_kubernetes :
+  vpc_service_projects_platform_managed = {
+    for team_key, project in module.google_project_platform_managed :
     team_key => {
       id     = project.id
       number = project.number

--- a/main.tofu
+++ b/main.tofu
@@ -147,7 +147,7 @@ module "google_project_teams" {
   folder_id                       = module.core_helpers.teams[each.key].environments[local.environment_key]
   labels                          = local.team_labels[each.key]
   monthly_budget_amount           = var.project_monthly_budget_amount
-  prefix                          = split("-", each.key)[0]
+  prefix                          = each.key
   services                        = local.team_project_services[each.key]
 }
 

--- a/main.tofu
+++ b/main.tofu
@@ -527,7 +527,7 @@ resource "google_project_iam_member" "google_project_owners" {
 # Grant team service accounts owner role on their platform-managed projects.
 
 resource "google_project_iam_member" "platform_managed_project_owners" {
-  for_each = local.gke_teams_with_service_accounts
+  for_each = local.platform_managed_teams_with_service_accounts
 
   member  = "serviceAccount:${google_service_account.github_actions[each.key].email}"
   project = module.google_project_platform_managed[each.key].id

--- a/main.tofu
+++ b/main.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-datadog-google-integration
 
 module "datadog_google_integration" {
-  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=52c9646bfd977026b3e25cddcb87e65224796ca9" # v0.4.5
+  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=96d35be7846e15d3ea60c27dab0a6a72e259d3ae" # v0.4.6
 
   lifecycle {
     enabled = var.datadog_enable
@@ -17,7 +17,7 @@ module "datadog_google_integration" {
 }
 
 module "datadog_google_integration_datadog_projects" {
-  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=52c9646bfd977026b3e25cddcb87e65224796ca9" # v0.4.5
+  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=96d35be7846e15d3ea60c27dab0a6a72e259d3ae" # v0.4.6
 
   for_each                           = local.datadog_google_project_for_each
   api_key                            = var.datadog_api_key
@@ -28,7 +28,7 @@ module "datadog_google_integration_datadog_projects" {
 }
 
 module "datadog_google_integration_platform_managed_projects" {
-  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=52c9646bfd977026b3e25cddcb87e65224796ca9" # v0.4.5
+  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=96d35be7846e15d3ea60c27dab0a6a72e259d3ae" # v0.4.6
 
   for_each                           = local.datadog_platform_managed_for_each
   api_key                            = var.datadog_api_key
@@ -42,7 +42,7 @@ module "datadog_google_integration_platform_managed_projects" {
 # https://github.com/osinfra-io/pt-arche-google-network
 
 module "google_network_vpc" {
-  source = "github.com/osinfra-io/pt-arche-google-network?ref=68fb1e3db389fbeebde396ee61ba4ec3832123a7" # v0.3.5
+  source = "github.com/osinfra-io/pt-arche-google-network?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
 
   name       = "standard-shared"
   project    = module.google_project.id
@@ -53,7 +53,7 @@ module "google_network_vpc" {
 # https://github.com/osinfra-io/pt-arche-google-network
 
 module "google_network_osinfra_io_dns" {
-  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=68fb1e3db389fbeebde396ee61ba4ec3832123a7" # v0.3.5
+  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
 
   dns_name   = local.osinfra_io_dns_zone_name
   labels     = module.core_helpers.labels
@@ -63,7 +63,7 @@ module "google_network_osinfra_io_dns" {
 }
 
 module "google_network_private_dns" {
-  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=68fb1e3db389fbeebde396ee61ba4ec3832123a7" # v0.3.5
+  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
 
   dns_name = local.private_dns_zone_name
   labels   = module.core_helpers.labels
@@ -78,7 +78,7 @@ module "google_network_private_dns" {
 }
 
 module "google_network_team_dns" {
-  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=68fb1e3db389fbeebde396ee61ba4ec3832123a7" # v0.3.5
+  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
 
   for_each   = local.teams_with_dns_zones
   dns_name   = each.value.dns_name
@@ -92,7 +92,7 @@ module "google_network_team_dns" {
 # https://github.com/osinfra-io/pt-arche-google-project
 
 module "google_project" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=5b089b8cf6bee8d8853c855ca9fd9507a902cb51" # v0.7.0
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=dc72cc73addab260dc8cb3df719aa69b66b8b774" # v0.7.1
 
   billing_account       = var.project_billing_account
   deletion_policy       = "DELETE"
@@ -124,7 +124,7 @@ module "google_project" {
 }
 
 module "google_project_platform_managed" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=5b089b8cf6bee8d8853c855ca9fd9507a902cb51" # v0.7.0
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=dc72cc73addab260dc8cb3df719aa69b66b8b774" # v0.7.1
 
   for_each                        = local.teams_with_platform_managed_projects
   billing_account                 = var.project_billing_account
@@ -138,7 +138,7 @@ module "google_project_platform_managed" {
 }
 
 module "google_project_teams" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=5b089b8cf6bee8d8853c855ca9fd9507a902cb51" # v0.7.0
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=dc72cc73addab260dc8cb3df719aa69b66b8b774" # v0.7.1
 
   for_each                        = local.google_projects
   billing_account                 = var.project_billing_account

--- a/main.tofu
+++ b/main.tofu
@@ -99,7 +99,7 @@ module "google_project" {
   folder_id             = module.core_helpers.environment_folder_id
   labels                = module.core_helpers.labels
   monthly_budget_amount = var.project_monthly_budget_amount
-  prefix                = module.core_helpers.project_naming.prefix
+  prefix                = module.core_helpers.project_naming.team_key
 
   services = [
     "artifactregistry.googleapis.com",

--- a/main.tofu
+++ b/main.tofu
@@ -27,15 +27,15 @@ module "datadog_google_integration_datadog_projects" {
   project                            = module.google_project_teams[each.key].id
 }
 
-module "datadog_google_integration_kubernetes_projects" {
+module "datadog_google_integration_platform_managed_projects" {
   source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=52c9646bfd977026b3e25cddcb87e65224796ca9" # v0.4.5
 
-  for_each                           = local.datadog_kubernetes_for_each
+  for_each                           = local.datadog_platform_managed_for_each
   api_key                            = var.datadog_api_key
   is_cspm_enabled                    = true
   is_security_command_center_enabled = true
   labels                             = module.core_helpers.labels
-  project                            = module.google_project_kubernetes[each.key].id
+  project                            = module.google_project_platform_managed[each.key].id
 }
 
 # Google VPC Module (osinfra.io)
@@ -92,11 +92,10 @@ module "google_network_team_dns" {
 # https://github.com/osinfra-io/pt-arche-google-project
 
 module "google_project" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=8b86debb6614d96cb891b652754693a459e9efbb" # v0.6.10
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=5b089b8cf6bee8d8853c855ca9fd9507a902cb51" # v0.7.0
 
   billing_account       = var.project_billing_account
   deletion_policy       = "DELETE"
-  description           = module.core_helpers.project_naming.description
   folder_id             = module.core_helpers.environment_folder_id
   labels                = module.core_helpers.labels
   monthly_budget_amount = var.project_monthly_budget_amount
@@ -124,33 +123,31 @@ module "google_project" {
   ]
 }
 
-module "google_project_kubernetes" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=8b86debb6614d96cb891b652754693a459e9efbb" # v0.6.10
+module "google_project_platform_managed" {
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=5b089b8cf6bee8d8853c855ca9fd9507a902cb51" # v0.7.0
 
-  for_each                        = local.teams_with_gke_clusters
+  for_each                        = local.teams_with_platform_managed_projects
   billing_account                 = var.project_billing_account
   cis_2_2_logging_sink_project_id = module.google_project.id
   deletion_policy                 = "DELETE"
-  description                     = "k8s"
   folder_id                       = module.core_helpers.teams[each.key].environments[local.environment_key]
-  labels                          = merge(local.team_labels[each.key], { "project-type" = "kubernetes" })
-  monthly_budget_amount           = var.kubernetes_project_monthly_budget_amount
+  labels                          = merge(local.team_labels[each.key], { "project-type" = "platform-managed" })
+  monthly_budget_amount           = var.platform_managed_project_monthly_budget_amount
   prefix                          = each.key
-  services                        = local.kubernetes_project_services[each.key]
+  services                        = local.platform_managed_project_services[each.key]
 }
 
 module "google_project_teams" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=8b86debb6614d96cb891b652754693a459e9efbb" # v0.6.10
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=5b089b8cf6bee8d8853c855ca9fd9507a902cb51" # v0.7.0
 
   for_each                        = local.google_projects
   billing_account                 = var.project_billing_account
   cis_2_2_logging_sink_project_id = module.google_project.id
   deletion_policy                 = "DELETE"
-  description                     = local.team_project_descriptions[each.key]
   folder_id                       = module.core_helpers.teams[each.key].environments[local.environment_key]
   labels                          = local.team_labels[each.key]
   monthly_budget_amount           = var.project_monthly_budget_amount
-  prefix                          = local.team_project_prefixes[each.key]
+  prefix                          = split("-", each.key)[0]
   services                        = local.team_project_services[each.key]
 }
 
@@ -489,7 +486,7 @@ resource "google_kms_key_ring" "state_encryption" {
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/google_project_iam_member
 
 resource "google_project_iam_member" "container_engine_firewall_management" {
-  for_each = local.vpc_service_projects_kubernetes
+  for_each = local.vpc_service_projects_platform_managed
 
   member  = "serviceAccount:service-${each.value.number}@container-engine-robot.iam.gserviceaccount.com"
   project = module.google_project.id
@@ -497,7 +494,7 @@ resource "google_project_iam_member" "container_engine_firewall_management" {
 }
 
 resource "google_project_iam_member" "container_engine_service_agent_user" {
-  for_each = local.vpc_service_projects_kubernetes
+  for_each = local.vpc_service_projects_platform_managed
 
   member  = "serviceAccount:service-${each.value.number}@container-engine-robot.iam.gserviceaccount.com"
   project = module.google_project.id
@@ -526,26 +523,26 @@ resource "google_project_iam_member" "google_project_owners" {
   role    = "roles/owner"
 }
 
-# Kubernetes Project Owners
-# Grant team service accounts owner role on their kubernetes_projects.
+# Platform-Managed Project Owners
+# Grant team service accounts owner role on their platform-managed projects.
 
-resource "google_project_iam_member" "kubernetes_project_owners" {
+resource "google_project_iam_member" "platform_managed_project_owners" {
   for_each = local.gke_teams_with_service_accounts
 
   member  = "serviceAccount:${google_service_account.github_actions[each.key].email}"
-  project = module.google_project_kubernetes[each.key].id
+  project = module.google_project_platform_managed[each.key].id
   role    = "roles/owner"
 }
 
-# Kubernetes Project Pneuma Owners
-# Grant the pt-pneuma service account owner role on all other teams' kubernetes projects
+# Platform-Managed Project Pneuma Owners
+# Grant the pt-pneuma service account owner role on all other teams' platform-managed projects
 # so pt-pneuma can provision and manage GKE clusters on behalf of all teams.
 
-resource "google_project_iam_member" "kubernetes_project_pneuma_owners" {
+resource "google_project_iam_member" "platform_managed_project_pneuma_owners" {
   for_each = local.gke_teams_for_pneuma_access
 
   member  = "serviceAccount:${google_service_account.github_actions["pt-pneuma"].email}"
-  project = module.google_project_kubernetes[each.key].id
+  project = module.google_project_platform_managed[each.key].id
   role    = "roles/owner"
 }
 
@@ -561,11 +558,11 @@ resource "google_project_iam_member" "multi_cluster_service_agents" {
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/google_project_service_identity
 
 resource "google_project_service_identity" "multi_cluster_service_agents" {
-  depends_on = [module.google_project_kubernetes]
+  depends_on = [module.google_project_platform_managed]
   for_each   = local.teams_with_gke_hub_host
   provider   = google-beta # Required for google_project_service_identity
 
-  project = module.google_project_kubernetes[each.key].id
+  project = module.google_project_platform_managed[each.key].id
   service = "multiclusterservicediscovery.googleapis.com"
 }
 

--- a/moved.tofu
+++ b/moved.tofu
@@ -5,3 +5,23 @@ moved {
   from = module.google_projects
   to   = module.google_project_teams
 }
+
+moved {
+  from = module.google_project_kubernetes
+  to   = module.google_project_platform_managed
+}
+
+moved {
+  from = module.datadog_google_integration_kubernetes_projects
+  to   = module.datadog_google_integration_platform_managed_projects
+}
+
+moved {
+  from = google_project_iam_member.kubernetes_project_owners
+  to   = google_project_iam_member.platform_managed_project_owners
+}
+
+moved {
+  from = google_project_iam_member.kubernetes_project_pneuma_owners
+  to   = google_project_iam_member.platform_managed_project_pneuma_owners
+}

--- a/outputs.tofu
+++ b/outputs.tofu
@@ -1,11 +1,11 @@
 # Output Values
 # https://opentofu.org/docs/language/values/outputs
 
-output "kubernetes_projects" {
-  description = "All Kubernetes projects created for each team with complete details"
+output "platform_managed_projects" {
+  description = "All platform-managed projects created for each team with complete details"
 
   value = {
-    for team_key, project in module.google_project_kubernetes :
+    for team_key, project in module.google_project_platform_managed :
     team_key => {
       environment = module.core_helpers.env
       id          = project.id
@@ -59,7 +59,7 @@ output "storage_buckets" {
 }
 
 output "teams" {
-  description = "All teams data from logos workspaces with Kubernetes projects enriched"
+  description = "All teams data from logos workspaces with platform-managed projects enriched"
 
   value = {
     for team_key, team in module.core_helpers.teams :
@@ -68,10 +68,10 @@ output "teams" {
         id = module.google_project_teams[team_key].id
       } : null
 
-      kubernetes_project = contains(keys(module.google_project_kubernetes), team_key) ? {
+      platform_managed_project = contains(keys(module.google_project_platform_managed), team_key) ? {
         environment = module.core_helpers.env
-        id          = module.google_project_kubernetes[team_key].id
-        number      = module.google_project_kubernetes[team_key].number
+        id          = module.google_project_platform_managed[team_key].id
+        number      = module.google_project_platform_managed[team_key].number
       } : null
     })
   }

--- a/regional/backend.tofu
+++ b/regional/backend.tofu
@@ -1,13 +1,1 @@
-# Backend Configuration
-# https://opentofu.org/docs/language/settings/backends/configuration
-
-terraform {
-  # Google Cloud Storage
-  # https://opentofu.org/docs/language/settings/backends/gcs
-
-  backend "gcs" {
-    bucket             = var.state_bucket
-    kms_encryption_key = var.state_kms_encryption_key
-    prefix             = var.state_prefix
-  }
-}
+../shared/backend.tofu

--- a/regional/backend.tofu
+++ b/regional/backend.tofu
@@ -1,1 +1,13 @@
-../shared/backend.tofu
+# Backend Configuration
+# https://opentofu.org/docs/language/settings/backends/configuration
+
+terraform {
+  # Google Cloud Storage
+  # https://opentofu.org/docs/language/settings/backends/gcs
+
+  backend "gcs" {
+    bucket             = var.state_bucket
+    kms_encryption_key = var.state_kms_encryption_key
+    prefix             = var.state_prefix
+  }
+}

--- a/regional/helpers.tofu
+++ b/regional/helpers.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=1024a5446b33be60bba2d52897ba4f487cb469ed" # v0.2.3
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
 
   cost_center         = "x001"
   data_classification = "public"

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-google-network
 
 module "google_network_master_subnets" {
-  source = "github.com/osinfra-io/pt-arche-google-network//regional?ref=68fb1e3db389fbeebde396ee61ba4ec3832123a7" # v0.3.5
+  source = "github.com/osinfra-io/pt-arche-google-network//regional?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
 
   for_each                 = local.regional_subnets
   ip_cidr_range            = each.value.master_ipv4_cidr_block
@@ -13,7 +13,7 @@ module "google_network_master_subnets" {
 }
 
 module "google_network_subnets" {
-  source = "github.com/osinfra-io/pt-arche-google-network//regional?ref=68fb1e3db389fbeebde396ee61ba4ec3832123a7" # v0.3.5
+  source = "github.com/osinfra-io/pt-arche-google-network//regional?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
 
   for_each                 = local.regional_subnets
   ip_cidr_range            = each.value.ip_cidr_range
@@ -35,7 +35,7 @@ module "google_network_subnets" {
 }
 
 module "google_network_cloud_nat" {
-  source = "github.com/osinfra-io/pt-arche-google-network//regional/nat?ref=68fb1e3db389fbeebde396ee61ba4ec3832123a7" # v0.3.5
+  source = "github.com/osinfra-io/pt-arche-google-network//regional/nat?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
 
   depends_on = [
     module.google_network_subnets

--- a/variables.tofu
+++ b/variables.tofu
@@ -31,9 +31,9 @@ variable "google_customer_id" {
   type        = string
 }
 
-variable "kubernetes_project_monthly_budget_amount" {
+variable "platform_managed_project_monthly_budget_amount" {
   default     = 5
-  description = "The monthly budget amount in USD to set for Kubernetes projects"
+  description = "The monthly budget amount in USD to set for platform-managed projects"
   type        = number
 }
 

--- a/variables.tofu
+++ b/variables.tofu
@@ -35,6 +35,11 @@ variable "platform_managed_project_monthly_budget_amount" {
   default     = 5
   description = "The monthly budget amount in USD to set for platform-managed projects"
   type        = number
+
+  validation {
+    condition     = var.platform_managed_project_monthly_budget_amount > 0
+    error_message = "The platform_managed_project_monthly_budget_amount must be greater than 0."
+  }
 }
 
 variable "osinfra_io_ns_delegations" {
@@ -58,6 +63,11 @@ variable "project_monthly_budget_amount" {
   default     = 5
   description = "The monthly budget amount in USD to set for the project"
   type        = number
+
+  validation {
+    condition     = var.project_monthly_budget_amount > 0
+    error_message = "The project_monthly_budget_amount must be greater than 0."
+  }
 }
 
 # These three state_* variables are required for early variable evaluation for backend and provider configuration.


### PR DESCRIPTION
## Summary

Renames the per-team "kubernetes project" to a "platform-managed project" so that managed data services (Cloud SQL, Redis) can coexist with GKE clusters in the same project. Also removes `description` from all project module calls — project IDs now use `{prefix}-{random}-{env}` format.

Part of platform re-architecture to support data services. See also:
- [pt-arche-google-project#176](https://github.com/osinfra-io/pt-arche-google-project/pull/176) (merged — v0.7.0)
- [pt-arche-core-helpers#41](https://github.com/osinfra-io/pt-arche-core-helpers/pull/41) (merged — v0.3.0)

## Changes

### `main.tofu`
- `module "google_project_kubernetes"` → `module "google_project_platform_managed"`
  - Remove `description = "k8s"`
  - Change label `"project-type" = "kubernetes"` → `"project-type" = "platform-managed"`
  - Rename `monthly_budget_amount` and `services` var/local refs
- `module "google_project"`: Remove `description = module.core_helpers.project_naming.description`
- `module "google_project_teams"`: Remove `description`; inline `prefix = split("-", each.key)[0]`
- `module "datadog_google_integration_kubernetes_projects"` → `module "datadog_google_integration_platform_managed_projects"`
- `resource "google_project_iam_member" "kubernetes_project_owners"` → `"platform_managed_project_owners"`
- `resource "google_project_iam_member" "kubernetes_project_pneuma_owners"` → `"platform_managed_project_pneuma_owners"`
- Bump `pt-arche-google-project` to v0.7.0

### `locals.tofu`
- Rename all `kubernetes`/`k8s` locals to `platform_managed`
- Remove `team_project_descriptions` and `team_project_prefixes` (no longer needed)

### `variables.tofu`
- Rename `kubernetes_project_monthly_budget_amount` → `platform_managed_project_monthly_budget_amount`

### `outputs.tofu`
- Rename `output "kubernetes_projects"` → `"platform_managed_projects"`
- Rename `kubernetes_project` field in `teams` output → `platform_managed_project`

### `moved.tofu`
- Add moved blocks for all renamed modules and resources

## ⚠️ State migration required

Removing `description` changes the computed `project_id` for all projects. Since GCP project IDs are immutable, all affected projects must be removed from state and recreated per environment before applying:

```bash
tofu state rm 'module.google_project_platform_managed["<team_key>"]'
```

Also remove and recreate `module.google_project` and each `module.google_project_teams[*]` entry (their descriptions also changed — they no longer embed the description segment).

Deploy order: **Sandbox → Non-Production → Production**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated configuration from Kubernetes‑specific projects to platform‑managed projects; Datadog integrations, project outputs, and project/service wiring renamed and re‑scoped to platform‑managed equivalents.

* **Chores**
  * Added state‑migration mappings to preserve resources during the transition.
  * Upgraded several infrastructure modules and core helper refs, added remote backend configs, and introduced budget validation for platform‑managed projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->