### PR TITLE
Add Cloud SQL provisioning for platform-managed projects

### DIFF
--- a/helpers.tofu
+++ b/helpers.tofu
@@ -13,7 +13,8 @@ module "core_helpers" {
     "pt-kryptos-main-production",
     "pt-logos-main-production",
     "pt-pneuma-main-production",
-    "pt-techne-main-production"
+    "pt-techne-main-production",
+    "st-ethos-main-production"
   ]
 
   repository = "pt-corpus"

--- a/locals.tofu
+++ b/locals.tofu
@@ -138,6 +138,7 @@ locals {
         "serviceusage.googleapis.com",
         "trafficdirector.googleapis.com"
       ],
+      contains(keys(local.teams_with_cloud_sql), k) ? ["sqladmin.googleapis.com"] : [],
       v.has_gke_hub_host ? [
         "gkehub.googleapis.com",
         "multiclusteringress.googleapis.com"
@@ -244,6 +245,14 @@ locals {
     if contains(keys(team.identity_groups), "registry-readers") &&
     contains(keys(team.identity_groups), "registry-writers") &&
     team.enable_workflows
+  }
+
+  # Teams with Cloud SQL
+  # Teams that have opted in to Cloud SQL in their platform-managed project
+  teams_with_cloud_sql = {
+    for team_key, team in local.teams_with_platform_managed_projects :
+    team_key => team
+    if try(team.platform_managed_project.cloud_sql != null, false)
   }
 
   # Teams with DNS Zones

--- a/locals.tofu
+++ b/locals.tofu
@@ -252,7 +252,7 @@ locals {
   teams_with_cloud_sql = {
     for team_key, team in local.teams_with_platform_managed_projects :
     team_key => team
-    if try(team.platform_managed_project.cloud_sql != null, false)
+    if length(tolist(team.platform_managed_project.cloud_sql.regions)) > 0
   }
 
   # Teams with DNS Zones

--- a/locals.tofu
+++ b/locals.tofu
@@ -138,7 +138,7 @@ locals {
         "serviceusage.googleapis.com",
         "trafficdirector.googleapis.com"
       ],
-      contains(keys(local.teams_with_cloud_sql), k) ? ["sqladmin.googleapis.com"] : [],
+      contains(keys(local.teams_with_cloud_sql), k) ? ["servicenetworking.googleapis.com", "sqladmin.googleapis.com"] : [],
       v.has_gke_hub_host ? [
         "gkehub.googleapis.com",
         "multiclusteringress.googleapis.com"

--- a/main.tofu
+++ b/main.tofu
@@ -119,6 +119,7 @@ module "google_project" {
     "securitycenter.googleapis.com",
     "servicenetworking.googleapis.com",
     "serviceusage.googleapis.com",
+    "sqladmin.googleapis.com",
     "sts.googleapis.com"
   ]
 }

--- a/main.tofu
+++ b/main.tofu
@@ -92,7 +92,7 @@ module "google_network_team_dns" {
 # https://github.com/osinfra-io/pt-arche-google-project
 
 module "google_project" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=dc72cc73addab260dc8cb3df719aa69b66b8b774" # v0.7.1
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=3e0113c1a331ea399eeac2fd7528516c682eef4f" # v0.7.3
 
   billing_account       = var.project_billing_account
   deletion_policy       = "DELETE"
@@ -124,7 +124,7 @@ module "google_project" {
 }
 
 module "google_project_platform_managed" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=dc72cc73addab260dc8cb3df719aa69b66b8b774" # v0.7.1
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=3e0113c1a331ea399eeac2fd7528516c682eef4f" # v0.7.3
 
   for_each                        = local.teams_with_platform_managed_projects
   billing_account                 = var.project_billing_account
@@ -138,7 +138,7 @@ module "google_project_platform_managed" {
 }
 
 module "google_project_teams" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=dc72cc73addab260dc8cb3df719aa69b66b8b774" # v0.7.1
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=3e0113c1a331ea399eeac2fd7528516c682eef4f" # v0.7.3
 
   for_each                        = local.google_projects
   billing_account                 = var.project_billing_account

--- a/outputs.tofu
+++ b/outputs.tofu
@@ -7,6 +7,7 @@ output "platform_managed_projects" {
   value = {
     for team_key, project in module.google_project_platform_managed :
     team_key => {
+      cloud_sql   = module.core_helpers.teams[team_key].platform_managed_project.cloud_sql
       environment = module.core_helpers.env
       id          = project.id
       number      = project.number

--- a/regional/.terraform.lock.hcl
+++ b/regional/.terraform.lock.hcl
@@ -22,3 +22,19 @@ provider "registry.opentofu.org/hashicorp/google" {
     "zh:f54f34576966895fbf99fe0c180d086f799e937bbacb259e3a1a5a57e7cd0f9e",
   ]
 }
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version = "3.8.1"
+  hashes = [
+    "h1:EHn3jsqOKhWjbg0X+psk0Ww96yz3N7ASqEKKuFvDFwo=",
+    "zh:25c458c7c676f15705e872202dad7dcd0982e4a48e7ea1800afa5fc64e77f4c8",
+    "zh:2edeaf6f1b20435b2f81855ad98a2e70956d473be9e52a5fdf57ccd0098ba476",
+    "zh:44becb9d5f75d55e36dfed0c5beabaf4c92e0a2bc61a3814d698271c646d48e7",
+    "zh:7699032612c3b16cc69928add8973de47b10ce81b1141f30644a0e8a895b5cd3",
+    "zh:86d07aa98d17703de9fbf402c89590dc1e01dbe5671dd6bc5e487eb8fe87eee0",
+    "zh:8c411c77b8390a49a8a1bc9f176529e6b32369dd33a723606c8533e5ca4d68c1",
+    "zh:a5ecc8255a612652a56b28149994985e2c4dc046e5d34d416d47fa7767f5c28f",
+    "zh:aea3fe1a5669b932eda9c5c72e5f327db8da707fe514aaca0d0ef60cb24892f9",
+    "zh:f56e26e6977f755d7ae56fa6320af96ecf4bb09580d47cb481efbf27f1c5afff",
+  ]
+}

--- a/regional/locals.tofu
+++ b/regional/locals.tofu
@@ -8,4 +8,14 @@ locals {
   # Regional subnets
   # Filter subnets for the current region from the main state
   regional_subnets = lookup(local.main.regional_subnets, module.core_helpers.region, {})
+
+  # Teams with Cloud SQL in the current region
+  # Filter platform-managed teams that have Cloud SQL configured for the current deployment region
+  teams_with_cloud_sql_in_region = {
+    for team_key, team in module.core_helpers.teams :
+    team_key => team
+    if try(team.platform_managed_project.cloud_sql != null, false) &&
+    contains(tolist(try(team.platform_managed_project.cloud_sql.regions, [])), module.core_helpers.region) &&
+    contains(keys(local.main.platform_managed_projects), team_key)
+  }
 }

--- a/regional/locals.tofu
+++ b/regional/locals.tofu
@@ -14,8 +14,8 @@ locals {
   teams_with_cloud_sql_in_region = {
     for team_key, team in module.core_helpers.teams :
     team_key => team
-    if try(team.platform_managed_project.cloud_sql != null, false) &&
-    contains(tolist(try(team.platform_managed_project.cloud_sql.regions, [])), module.core_helpers.region) &&
+    if length(tolist(team.platform_managed_project.cloud_sql.regions)) > 0 &&
+    contains(tolist(team.platform_managed_project.cloud_sql.regions), module.core_helpers.region) &&
     contains(keys(local.main.platform_managed_projects), team_key)
   }
 }

--- a/regional/locals.tofu
+++ b/regional/locals.tofu
@@ -10,12 +10,11 @@ locals {
   regional_subnets = lookup(local.main.regional_subnets, module.core_helpers.region, {})
 
   # Teams with Cloud SQL in the current region
-  # Filter platform-managed teams that have Cloud SQL configured for the current deployment region
+  # Filter platform-managed projects that have Cloud SQL configured for the current deployment region
   teams_with_cloud_sql_in_region = {
-    for team_key, team in module.core_helpers.teams :
-    team_key => team
-    if length(tolist(team.platform_managed_project.cloud_sql.regions)) > 0 &&
-    contains(tolist(team.platform_managed_project.cloud_sql.regions), module.core_helpers.region) &&
-    contains(keys(local.main.platform_managed_projects), team_key)
+    for team_key, project in local.main.platform_managed_projects :
+    team_key => project
+    if length(tolist(project.cloud_sql.regions)) > 0 &&
+    contains(tolist(project.cloud_sql.regions), module.core_helpers.region)
   }
 }

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -1,3 +1,22 @@
+# Google Cloud SQL Module (osinfra.io)
+# https://github.com/osinfra-io/pt-arche-google-cloud-sql
+
+module "google_cloud_sql" {
+  source = "github.com/osinfra-io/pt-arche-google-cloud-sql//regional?ref=4445c35bbe2f679c301ac5f335b9ad03821527e1" # v0.2.7
+
+  for_each = local.teams_with_cloud_sql_in_region
+
+  database_version    = each.value.platform_managed_project.cloud_sql.database_version
+  deletion_protection = module.core_helpers.env == "prod"
+  host_project_id     = local.main.project_id
+  instance_name       = each.key
+  labels              = merge(module.core_helpers.labels, { team = each.key })
+  machine_tier        = each.value.platform_managed_project.cloud_sql.machine_tier
+  network             = local.main.vpc_name
+  project             = local.main.platform_managed_projects[each.key].id
+  region              = module.core_helpers.region
+}
+
 # Google Subnet Module (osinfra.io)
 # https://github.com/osinfra-io/pt-arche-google-network
 

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -6,14 +6,14 @@ module "google_cloud_sql" {
 
   for_each = local.teams_with_cloud_sql_in_region
 
-  database_version    = each.value.platform_managed_project.cloud_sql.database_version
+  database_version    = each.value.cloud_sql.database_version
   deletion_protection = module.core_helpers.env == "prod"
   host_project_id     = local.main.project_id
   instance_name       = each.key
   labels              = merge(module.core_helpers.labels, { team = each.key })
-  machine_tier        = each.value.platform_managed_project.cloud_sql.machine_tier
+  machine_tier        = each.value.cloud_sql.machine_tier
   network             = local.main.vpc_name
-  project             = local.main.platform_managed_projects[each.key].id
+  project             = each.value.id
   region              = module.core_helpers.region
 }
 

--- a/regional/outputs.tofu
+++ b/regional/outputs.tofu
@@ -1,0 +1,13 @@
+# Output Values
+# https://opentofu.org/docs/language/values/outputs
+
+output "cloud_sql_instances" {
+  description = "Cloud SQL instances created for each team in this region"
+  value = {
+    for team_key, sql in module.google_cloud_sql :
+    team_key => {
+      instance           = sql.instance
+      private_ip_address = sql.private_ip_address
+    }
+  }
+}

--- a/regional/providers.tofu
+++ b/regional/providers.tofu
@@ -40,6 +40,13 @@ terraform {
     google = {
       source = "hashicorp/google"
     }
+
+    # Random Provider
+    # https://search.opentofu.org/provider/hashicorp/random/latest/docs
+
+    random = {
+      source = "hashicorp/random"
+    }
   }
 }
 


### PR DESCRIPTION
## What

Provisions a Cloud SQL PostgreSQL instance per declared region in a team's platform-managed project, using the `pt-arche-google-cloud-sql` module. Private IP only, via the existing Shared VPC peering connection.

## Changes

- **`locals.tofu`** — Add `teams_with_cloud_sql` filter; conditionally enable `sqladmin.googleapis.com` for those teams
- **`regional/locals.tofu`** — Add `teams_with_cloud_sql_in_region` filtered to current region
- **`regional/main.tofu`** — Add `google_cloud_sql` module (`pt-arche-google-cloud-sql//regional` v0.2.7); `deletion_protection = false` in sb/nonprod, `true` in prod
- **`regional/providers.tofu`** — Add `random` provider (required by arche SQL module)
- **`regional/outputs.tofu`** — Expose `cloud_sql_instances` (instance name + private IP per team)
- **`regional/.terraform.lock.hcl`** — Lock `hashicorp/random v3.8.1`

## Related

Schema: osinfra-io/pt-logos#add-cloud-sql  
Docs: osinfra-io/pt-ekklesia-docs#add-cloud-sql

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-team, per-region Cloud SQL provisioning for teams that opt into Cloud SQL, with deletion protection enabled in production.
  * Conditional enabling of the Cloud SQL API for applicable teams.
  * New output exporting a map of Cloud SQL instances per team, including instance identifiers and private IPs for connectivity.

* **Chores**
  * Added provider requirement and updated lockfile entries to support the new resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->