### PR TITLE
Update pt-corpus: add st-foo logos workspace

### DIFF
--- a/helpers.tofu
+++ b/helpers.tofu
@@ -14,7 +14,8 @@ module "core_helpers" {
     "pt-logos-main-production",
     "pt-pneuma-main-production",
     "pt-techne-main-production",
-    "st-ethos-main-production"
+    "st-ethos-main-production",
+    "st-foo-main-production"
   ]
 
   repository = "pt-corpus"


### PR DESCRIPTION
## Summary

Registers `st-foo-main-production` as a logos workspace in pt-corpus so Corpus can provision the team's GCP project and GKE subnet when it next runs.

Merge after the logos deployment completes (after pt-logos PR #2 merges and the production workflow finishes).

## Changes

- `helpers.tofu` — adds `st-foo-main-production` to `logos_workspaces`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended workspace configuration with an additional workspace identifier for platform infrastructure management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->