### PR TITLE
Update pre-commit hooks and add tofu-scan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/osinfra-io/pt-techne-pre-commit-hooks
-    rev: fe697ad1e9131053bd379a1ca110904f220612fd # frozen: v0.1.3
+    rev: bf174b5f94101025ee45458e820d7ad693e21df1 # frozen: v0.1.5
     hooks:
       - id: tofu-fmt
         verbose: true
@@ -22,4 +22,7 @@ repos:
       # export TF_PLUGIN_CACHE_DIR=$HOME/.opentofu.d/plugin-cache
 
       - id: tofu-validate
+        verbose: true
+
+      - id: tofu-scan
         verbose: true


### PR DESCRIPTION
Update pre-commit hooks:

- Bump `pt-techne-pre-commit-hooks` to v0.1.4
- Add `tofu-scan` hook for CIS benchmark scanning (GCP Foundation v3.0.0 + GKE v1.6.1)
- Pin all hook revisions to frozen commit SHAs