### PR TITLE
Restrict dangerous workflow triggers and add least-privilege permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,8 @@
 name: Dependabot Approve and Merge
 
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,6 +19,7 @@ concurrency:
 # caller workflow level or in the specific job that calls the reusable workflow.
 
 permissions:
+  actions: read
   contents: read
   id-token: write
 
@@ -40,6 +41,8 @@ jobs:
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: main-production
       workload_identity_provider: projects/557265520053/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
+    # Safe to pass secrets here: workflow_run is scoped to branches: [main],
+    # which prevents fork pull requests from triggering this workflow.
     secrets:
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
## Summary

Hardens two workflow files against risks posed by `pull_request_target` and `workflow_run` triggers, both of which run with base repository privileges.

### `dependabot.yml`
- Adds explicit `types: [opened, synchronize, reopened]` to the `pull_request_target` trigger (already the implicit default; making it explicit documents intent and reduces reliance on defaults)

### `production.yml`
- Adds `actions: read` to the `permissions` block — best practice when reading `workflow_run` event context
- Adds inline comment documenting why it is safe to pass secrets in this workflow: the `branches: [main]` filter on the `workflow_run` trigger prevents fork pull requests from triggering this workflow

Existing mitigations remain in place: `branches: [main]` scope restriction, `conclusion == 'success'` check, OIDC-based GCP authentication.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal CI/CD workflow configurations with improved trigger specifications and explicit security permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-corpus/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->