### PR TITLE
Update pt-corpus: add et-delete logos workspace

### DIFF
--- a/helpers.tofu
+++ b/helpers.tofu
@@ -9,6 +9,7 @@ module "core_helpers" {
 
   # Logos functionality - consolidated into core-helpers
   logos_workspaces = [
+    "et-delete-main-production",
     "pt-corpus-main-production",
     "pt-kryptos-main-production",
     "pt-logos-main-production",


### PR DESCRIPTION
Adds `et-delete-main-production` to the `logos_workspaces` list in `helpers.tofu` so that Corpus can provision infrastructure for the new et-delete enabling team.\n\nThis PR should be merged after the logos deployment (pt-logos PR #155) completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to support an additional production workspace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-corpus/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->