### PR TITLE
Update pt-corpus: add et-test logos workspace

### DIFF
--- a/helpers.tofu
+++ b/helpers.tofu
@@ -9,6 +9,7 @@ module "core_helpers" {
 
   # Logos functionality - consolidated into core-helpers
   logos_workspaces = [
+    "et-test-main-production",
     "pt-corpus-main-production",
     "pt-kryptos-main-production",
     "pt-logos-main-production",


### PR DESCRIPTION
Adds `et-test-main-production` to the `logos_workspaces` list in `helpers.tofu` so that Corpus can read et-test's Logos remote state after the team is onboarded.\n\nPart of et-test team onboarding. Merge after the logos deployment finishes (PR osinfra-io/pt-logos#157 merges and workflow completes).