### PR TITLE
Update pt-corpus: add pt-kratos logos workspace

### DIFF
--- a/helpers.tofu
+++ b/helpers.tofu
@@ -10,6 +10,7 @@ module "core_helpers" {
   # Logos functionality - consolidated into core-helpers
   logos_workspaces = [
     "pt-corpus-main-production",
+    "pt-kratos-main-production",
     "pt-kryptos-main-production",
     "pt-logos-main-production",
     "pt-pneuma-main-production",


### PR DESCRIPTION
Adds `pt-kratos-main-production` to `logos_workspaces` in `helpers.tofu` so pt-corpus can provision the platform-managed project for the new pt-kratos team.\n\nOpened by the Nomos Agent. Merge after the pt-logos deployment (PR #164) completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new production workspace configuration to expand deployment and operational support capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->