### PR TITLE
Grant member cluster compute SAs read access to hub team's Artifact Registry

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -234,10 +234,19 @@ locals {
   teams_with_artifact_registries = {
     for team_key, team in module.core_helpers.teams :
     team_key => {
-      registry_readers = [
-        "group:${team.identity_groups["registry-readers"].email}",
-        "serviceAccount:${module.google_project_platform_managed[team_key].number}-compute@developer.gserviceaccount.com"
-      ]
+      registry_readers = concat(
+        [
+          "group:${team.identity_groups["registry-readers"].email}",
+          "serviceAccount:${module.google_project_platform_managed[team_key].number}-compute@developer.gserviceaccount.com"
+        ],
+        # GKE Hub hosts serve member clusters that pull images from the hub team's registry
+        # (e.g. Istio images). Grant read access to all other platform-managed compute SAs.
+        try(local.teams_with_platform_managed_projects[team_key].has_gke_hub_host, false) ? [
+          for k, p in module.google_project_platform_managed :
+          "serviceAccount:${p.number}-compute@developer.gserviceaccount.com"
+          if k != team_key
+        ] : []
+      )
       registry_writers = [
         "group:${team.identity_groups["registry-writers"].email}"
       ]

--- a/locals.tofu
+++ b/locals.tofu
@@ -236,15 +236,15 @@ locals {
     team_key => {
       registry_readers = concat(
         [
-          "group:${team.identity_groups["registry-readers"].email}",
-          "serviceAccount:${module.google_project_platform_managed[team_key].number}-compute@developer.gserviceaccount.com"
+          "group:${team.identity_groups["registry-readers"].email}"
         ],
         # GKE Hub hosts serve member clusters that pull images from the hub team's registry
-        # (e.g. Istio images). Grant read access to all other platform-managed compute SAs.
+        # (e.g. Istio images). Include the registry-readers group of every other team with
+        # a platform-managed project so their node SAs (which join that group) have access.
         try(local.teams_with_platform_managed_projects[team_key].has_gke_hub_host, false) ? [
-          for k, p in module.google_project_platform_managed :
-          "serviceAccount:${p.number}-compute@developer.gserviceaccount.com"
-          if k != team_key
+          for k, other_team in module.core_helpers.teams :
+          "group:${other_team.identity_groups["registry-readers"].email}"
+          if k != team_key && contains(keys(other_team.identity_groups), "registry-readers")
         ] : []
       )
       registry_writers = [

--- a/locals.tofu
+++ b/locals.tofu
@@ -242,9 +242,9 @@ locals {
         # (e.g. Istio images). Include the registry-readers group of every other team with
         # a platform-managed project so their node SAs (which join that group) have access.
         try(local.teams_with_platform_managed_projects[team_key].has_gke_hub_host, false) ? [
-          for k, other_team in module.core_helpers.teams :
-          "group:${other_team.identity_groups["registry-readers"].email}"
-          if k != team_key && contains(keys(other_team.identity_groups), "registry-readers")
+          for k, other_team in local.teams_with_platform_managed_projects :
+          "group:${module.core_helpers.teams[k].identity_groups["registry-readers"].email}"
+          if k != team_key && contains(keys(module.core_helpers.teams[k].identity_groups), "registry-readers")
         ] : []
       )
       registry_writers = [


### PR DESCRIPTION
GKE fleet member clusters (e.g. pt-kryptos) pull Istio images from the hub team's (pt-pneuma) Artifact Registry virtual repository. Without read access, node pools get `403 Forbidden` / `ImagePullBackOff` errors.

**Root cause:** `registry_readers` for each team's virtual repo only included that team's own compute SA. Member clusters' node pools use their own project's compute SA, which had no access to the pneuma registry.

**Fix:** For any team that is a GKE Hub host (`enable_gke_hub_host = true`), automatically add the compute SAs of all other platform-managed teams to `registry_readers`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved container registry read access for teams with hub-host capability by always including the team’s own `registry-readers` group and deriving additional read permissions from eligible other teams’ `registry-readers` groups (excluding the current team).
* **Bug Fixes**
  * Kept existing registry access behavior unchanged for teams without that capability.
  * Removed the prior inclusion of the platform-managed compute account as a registry-reader principal, aligning permissions with the intended access model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->