### PR TITLE
Remove wrapper locals and make WIF resources direct

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -15,14 +15,6 @@ locals {
   # Browser group - centrally managed in pt-logos, referenced here for membership management
   browser_group_name = module.core_helpers.teams["pt-corpus"].identity_groups["${lower(local.environment_key)}-browsers"].name
 
-  # Datadog Google project for_each
-  # Resolves the for_each for the google_project_datadog module: enabled only when var.datadog_enable is true
-  datadog_google_project_for_each = var.datadog_enable ? local.google_projects_with_datadog : {}
-
-  # Datadog platform-managed for_each
-  # Resolves the for_each for the platform_managed_datadog module: enabled only when var.datadog_enable is true
-  datadog_platform_managed_for_each = var.datadog_enable ? local.teams_with_platform_managed_datadog : {}
-
   # Enable Cloud Cost Management only in production
   enable_cloud_cost_management = module.core_helpers.env == "prod"
 
@@ -326,54 +318,4 @@ locals {
       }
     }
   )
-
-  # VPC Service Projects for platform-managed
-  # Only platform-managed projects that need GKE-specific IAM permissions
-  # Keys must be statically known at plan time, so team_key is used instead of project.id
-  vpc_service_projects_platform_managed = {
-    for team_key, project in module.google_project_platform_managed :
-    team_key => {
-      id     = project.id
-      number = project.number
-    }
-  }
-
-  # Workload Identity
-  # Configuration for external identity provider authentication
-
-  workload_identity = {
-
-    "github-actions" = {
-
-      # An attribute condition is a Common Expression Language (CEL) expression that can check assertion attributes and
-      # target attributes. If the attribute condition evaluates to true for a given credential, the credential is accepted.
-      # Otherwise, the credential is rejected.
-
-      # Some of the claims embedded in the GitHub Actions OIDC token are not guaranteed to be unique, and tokens issued by
-      # other GitHub organizations or repositories may contain the same values, allowing them to establish an identity.
-      # To protect against this situation, always use an attribute condition to restrict access to tokens issued by your
-      # GitHub organization.
-
-      # GitHub guarantees the following ID to be unique and never re-used. This will protect against cybersquatting attacks.
-
-      # To get the organization id, you can run the following curl command with a token that has the read:org scope against
-      # your existing organization:
-
-      # curl -H "Authorization: token $GITHUB_READ_ORG_TOKEN" https://api.github.com/orgs/osinfra-io
-
-      attribute_condition = module.core_helpers.env == "sb" ? "assertion.repository_owner_id==\"104685378\"" : "assertion.repository_owner_id==\"104685378\" && (${join(" || ", local.github_actions_ref_conditions)})"
-
-      # The tokens issued by your external identity provider contain one or more attributes. Some identity providers refer
-      # to these attributes as claims. An attribute mapping defines how to derive the value of the Google STS token attribute
-      # from an external token.
-
-      attribute_mapping = {
-        "attribute.repository" = "assertion.repository"
-        "google.subject"       = "assertion.sub"
-      }
-
-      display_name = "GitHub Actions"
-      issuer_uri   = "https://token.actions.githubusercontent.com"
-    }
-  }
 }

--- a/main.tofu
+++ b/main.tofu
@@ -19,7 +19,7 @@ module "datadog_google_integration" {
 module "datadog_google_integration_datadog_projects" {
   source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=96d35be7846e15d3ea60c27dab0a6a72e259d3ae" # v0.4.6
 
-  for_each                           = local.datadog_google_project_for_each
+  for_each                           = var.datadog_enable ? local.google_projects_with_datadog : {}
   api_key                            = var.datadog_api_key
   is_cspm_enabled                    = true
   is_security_command_center_enabled = true
@@ -30,7 +30,7 @@ module "datadog_google_integration_datadog_projects" {
 module "datadog_google_integration_platform_managed_projects" {
   source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=96d35be7846e15d3ea60c27dab0a6a72e259d3ae" # v0.4.6
 
-  for_each                           = local.datadog_platform_managed_for_each
+  for_each                           = var.datadog_enable ? local.teams_with_platform_managed_datadog : {}
   api_key                            = var.datadog_api_key
   is_cspm_enabled                    = true
   is_security_command_center_enabled = true
@@ -392,35 +392,51 @@ resource "google_dns_record_set" "team_ns_delegations" {
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/iam_workload_identity_pool
 
 resource "google_iam_workload_identity_pool" "this" {
-  for_each = local.workload_identity
-
-  description               = "Workload Identity Pool for ${each.value.display_name}"
-  disabled                  = lookup(each.value, "disabled", false)
-  display_name              = each.value.display_name
+  description               = "Workload Identity Pool for GitHub Actions"
+  display_name              = "GitHub Actions"
   project                   = module.google_project.id
-  workload_identity_pool_id = each.key
+  workload_identity_pool_id = "github-actions"
 }
 
 # IAM Workload Identity Pool Provider Resource
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider
 
 resource "google_iam_workload_identity_pool_provider" "this" {
-  for_each = local.workload_identity
+  # An attribute condition is a Common Expression Language (CEL) expression that can check assertion attributes and
+  # target attributes. If the attribute condition evaluates to true for a given credential, the credential is accepted.
+  # Otherwise, the credential is rejected.
+  #
+  # Some of the claims embedded in the GitHub Actions OIDC token are not guaranteed to be unique, and tokens issued by
+  # other GitHub organizations or repositories may contain the same values, allowing them to establish an identity.
+  # To protect against this situation, always use an attribute condition to restrict access to tokens issued by your
+  # GitHub organization.
+  #
+  # GitHub guarantees the following ID to be unique and never re-used. This will protect against cybersquatting attacks.
+  #
+  # To get the organization id, you can run the following curl command with a token that has the read:org scope against
+  # your existing organization:
+  #
+  # curl -H "Authorization: token $GITHUB_READ_ORG_TOKEN" https://api.github.com/orgs/osinfra-io
+  attribute_condition = module.core_helpers.env == "sb" ? "assertion.repository_owner_id==\"104685378\"" : "assertion.repository_owner_id==\"104685378\" && (${join(" || ", local.github_actions_ref_conditions)})"
 
-  attribute_condition = each.value.attribute_condition
-  attribute_mapping   = each.value.attribute_mapping
-  description         = "Workload Identity Pool Provider for ${each.value.display_name}"
-  disabled            = lookup(each.value, "disabled", false)
-  display_name        = "${each.value.display_name} OIDC"
+  # The tokens issued by your external identity provider contain one or more attributes. Some identity providers refer
+  # to these attributes as claims. An attribute mapping defines how to derive the value of the Google STS token attribute
+  # from an external token.
+  attribute_mapping = {
+    "attribute.repository" = "assertion.repository"
+    "google.subject"       = "assertion.sub"
+  }
+
+  description  = "Workload Identity Pool Provider for GitHub Actions"
+  display_name = "GitHub Actions OIDC"
 
   oidc {
-    allowed_audiences = lookup(each.value, "allowed_audiences", [])
-    issuer_uri        = each.value.issuer_uri
+    issuer_uri = "https://token.actions.githubusercontent.com"
   }
 
   project                            = module.google_project.id
-  workload_identity_pool_id          = google_iam_workload_identity_pool.this[each.key].workload_identity_pool_id
-  workload_identity_pool_provider_id = "${each.key}-oidc"
+  workload_identity_pool_id          = google_iam_workload_identity_pool.this.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-actions-oidc"
 }
 
 # Google KMS Crypto Key Resource
@@ -487,7 +503,7 @@ resource "google_kms_key_ring" "state_encryption" {
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/google_project_iam_member
 
 resource "google_project_iam_member" "container_engine_firewall_management" {
-  for_each = local.vpc_service_projects_platform_managed
+  for_each = module.google_project_platform_managed
 
   member  = "serviceAccount:service-${each.value.number}@container-engine-robot.iam.gserviceaccount.com"
   project = module.google_project.id
@@ -495,7 +511,7 @@ resource "google_project_iam_member" "container_engine_firewall_management" {
 }
 
 resource "google_project_iam_member" "container_engine_service_agent_user" {
-  for_each = local.vpc_service_projects_platform_managed
+  for_each = module.google_project_platform_managed
 
   member  = "serviceAccount:service-${each.value.number}@container-engine-robot.iam.gserviceaccount.com"
   project = module.google_project.id
@@ -584,7 +600,7 @@ resource "google_service_account" "github_actions" {
 resource "google_service_account_iam_member" "github_actions" {
   for_each = local.github_repositories
 
-  member             = "principalSet://iam.googleapis.com/projects/${module.google_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.this["github-actions"].workload_identity_pool_id}/attribute.repository/osinfra-io/${each.value.repository}"
+  member             = "principalSet://iam.googleapis.com/projects/${module.google_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.this.workload_identity_pool_id}/attribute.repository/osinfra-io/${each.value.repository}"
   role               = "roles/iam.workloadIdentityUser"
   service_account_id = google_service_account.github_actions[each.value.name].id
 }

--- a/moved.tofu
+++ b/moved.tofu
@@ -2,6 +2,16 @@
 # https://opentofu.org/docs/language/moved
 
 moved {
+  from = google_iam_workload_identity_pool.this["github-actions"]
+  to   = google_iam_workload_identity_pool.this
+}
+
+moved {
+  from = google_iam_workload_identity_pool_provider.this["github-actions"]
+  to   = google_iam_workload_identity_pool_provider.this
+}
+
+moved {
   from = module.google_projects
   to   = module.google_project_teams
 }

--- a/outputs.tofu
+++ b/outputs.tofu
@@ -86,10 +86,9 @@ output "vpc_name" {
 output "workload_identity_pools" {
   description = "Workload Identity Pools created for external authentication"
   value = {
-    for key, pool in google_iam_workload_identity_pool.this :
-    key => {
-      name                      = pool.name
-      workload_identity_pool_id = pool.workload_identity_pool_id
+    (google_iam_workload_identity_pool.this.workload_identity_pool_id) = {
+      name                      = google_iam_workload_identity_pool.this.name
+      workload_identity_pool_id = google_iam_workload_identity_pool.this.workload_identity_pool_id
     }
   }
 }
@@ -97,10 +96,9 @@ output "workload_identity_pools" {
 output "workload_identity_providers" {
   description = "Workload Identity Pool Providers created for OIDC authentication"
   value = {
-    for key, provider in google_iam_workload_identity_pool_provider.this :
-    key => {
-      name                               = provider.name
-      workload_identity_pool_provider_id = provider.workload_identity_pool_provider_id
+    (google_iam_workload_identity_pool_provider.this.workload_identity_pool_provider_id) = {
+      name                               = google_iam_workload_identity_pool_provider.this.name
+      workload_identity_pool_provider_id = google_iam_workload_identity_pool_provider.this.workload_identity_pool_provider_id
     }
   }
 }


### PR DESCRIPTION
## Summary

Ponytail audit cleanup — three over-engineering cuts:

**Drop `datadog_google_project_for_each` / `datadog_platform_managed_for_each`**
Both were single-use wrapper locals: `var.datadog_enable ? <other_local> : {}`. Inlined directly on each module `for_each`.

**Drop `vpc_service_projects_platform_managed`**
A thin reshape of `module.google_project_platform_managed` (id + number) used in only two IAM member resources. The two `container_engine` IAM members now iterate directly over `module.google_project_platform_managed`.

**Drop `local.workload_identity` single-entry map**
A hardcoded `{"github-actions" = {...}}` map driving `for_each` on two resources — the key was already hardcoded again in the IAM binding reference, proving the abstraction leaked. Both WIF resources are now direct (no `for_each`). Security comments moved into the provider resource block. `moved` blocks added to preserve state.

**net: -34 lines**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated GitHub Actions workload identity integration.

* **Improvements**
  * Datadog integrations can now be enabled or disabled through configuration.
  * Simplified workload identity pool and provider outputs.
  * Updated IAM bindings to use the current platform-managed project configuration.

* **Migration**
  * Preserved existing Terraform state when transitioning workload identity resources to the updated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->