### PR TITLE
Update arche modules to latest releases

### DIFF
--- a/helpers.tofu
+++ b/helpers.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=7e9435f875ac91ac8538385fe8b4554dd068673e" # v0.3.2
 
   cost_center         = "x001"
   data_classification = "public"

--- a/main.tofu
+++ b/main.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-datadog-google-integration
 
 module "datadog_google_integration" {
-  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=96d35be7846e15d3ea60c27dab0a6a72e259d3ae" # v0.4.6
+  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=8ed8211e47a41fa6352ce66eeacb9ce71e13871b" # v0.4.7
 
   lifecycle {
     enabled = var.datadog_enable
@@ -17,7 +17,7 @@ module "datadog_google_integration" {
 }
 
 module "datadog_google_integration_datadog_projects" {
-  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=96d35be7846e15d3ea60c27dab0a6a72e259d3ae" # v0.4.6
+  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=8ed8211e47a41fa6352ce66eeacb9ce71e13871b" # v0.4.7
 
   for_each                           = var.datadog_enable ? local.google_projects_with_datadog : {}
   api_key                            = var.datadog_api_key
@@ -28,7 +28,7 @@ module "datadog_google_integration_datadog_projects" {
 }
 
 module "datadog_google_integration_platform_managed_projects" {
-  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=96d35be7846e15d3ea60c27dab0a6a72e259d3ae" # v0.4.6
+  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=8ed8211e47a41fa6352ce66eeacb9ce71e13871b" # v0.4.7
 
   for_each                           = var.datadog_enable ? local.teams_with_platform_managed_datadog : {}
   api_key                            = var.datadog_api_key
@@ -42,7 +42,7 @@ module "datadog_google_integration_platform_managed_projects" {
 # https://github.com/osinfra-io/pt-arche-google-network
 
 module "google_network_vpc" {
-  source = "github.com/osinfra-io/pt-arche-google-network?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
+  source = "github.com/osinfra-io/pt-arche-google-network?ref=a27322fd1ee0c4dc11cbfe34d3266a99ff8f075f" # v0.3.7
 
   name       = "standard-shared"
   project    = module.google_project.id
@@ -53,7 +53,7 @@ module "google_network_vpc" {
 # https://github.com/osinfra-io/pt-arche-google-network
 
 module "google_network_osinfra_io_dns" {
-  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
+  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=a27322fd1ee0c4dc11cbfe34d3266a99ff8f075f" # v0.3.7
 
   dns_name   = local.osinfra_io_dns_zone_name
   labels     = module.core_helpers.labels
@@ -63,7 +63,7 @@ module "google_network_osinfra_io_dns" {
 }
 
 module "google_network_private_dns" {
-  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
+  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=a27322fd1ee0c4dc11cbfe34d3266a99ff8f075f" # v0.3.7
 
   dns_name = local.private_dns_zone_name
   labels   = module.core_helpers.labels
@@ -78,7 +78,7 @@ module "google_network_private_dns" {
 }
 
 module "google_network_team_dns" {
-  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
+  source = "github.com/osinfra-io/pt-arche-google-network//dns?ref=a27322fd1ee0c4dc11cbfe34d3266a99ff8f075f" # v0.3.7
 
   for_each   = local.teams_with_dns_zones
   dns_name   = each.value.dns_name
@@ -92,7 +92,7 @@ module "google_network_team_dns" {
 # https://github.com/osinfra-io/pt-arche-google-project
 
 module "google_project" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=3e0113c1a331ea399eeac2fd7528516c682eef4f" # v0.7.3
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=5d44d4e269f0ac6e2d1b5d8adb3050b86c44c765" # v0.7.5
 
   billing_account       = var.project_billing_account
   deletion_policy       = "DELETE"
@@ -125,7 +125,7 @@ module "google_project" {
 }
 
 module "google_project_platform_managed" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=3e0113c1a331ea399eeac2fd7528516c682eef4f" # v0.7.3
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=5d44d4e269f0ac6e2d1b5d8adb3050b86c44c765" # v0.7.5
 
   for_each                        = local.teams_with_platform_managed_projects
   billing_account                 = var.project_billing_account
@@ -139,7 +139,7 @@ module "google_project_platform_managed" {
 }
 
 module "google_project_teams" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=3e0113c1a331ea399eeac2fd7528516c682eef4f" # v0.7.3
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=5d44d4e269f0ac6e2d1b5d8adb3050b86c44c765" # v0.7.5
 
   for_each                        = local.google_projects
   billing_account                 = var.project_billing_account
@@ -156,7 +156,7 @@ module "google_project_teams" {
 # https://github.com/osinfra-io/pt-arche-google-storage-bucket
 
 module "google_storage_bucket" {
-  source = "github.com/osinfra-io/pt-arche-google-storage-bucket?ref=b518fbdf3d480f827e2f360d97ce4d0600a3ff3b" # v0.3.4
+  source = "github.com/osinfra-io/pt-arche-google-storage-bucket?ref=cd834a64f19742466597c0bcb3f0078417a72fa0" # v0.3.5
 
   for_each = local.opentofu_state_management
   labels   = module.core_helpers.labels

--- a/regional/helpers.tofu
+++ b/regional/helpers.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=70c1e4f4a11acdcfc36055bdd3aa16579d4203a1" # v0.3.1
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=7e9435f875ac91ac8538385fe8b4554dd068673e" # v0.3.2
 
   cost_center         = "x001"
   data_classification = "public"

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-google-cloud-sql
 
 module "google_cloud_sql" {
-  source = "github.com/osinfra-io/pt-arche-google-cloud-sql//regional?ref=4445c35bbe2f679c301ac5f335b9ad03821527e1" # v0.2.7
+  source = "github.com/osinfra-io/pt-arche-google-cloud-sql//regional?ref=a1325d4daffb3e5b7f18c48d9780509cc33d5aec" # v0.2.8
 
   for_each = local.teams_with_cloud_sql_in_region
 
@@ -21,7 +21,7 @@ module "google_cloud_sql" {
 # https://github.com/osinfra-io/pt-arche-google-network
 
 module "google_network_master_subnets" {
-  source = "github.com/osinfra-io/pt-arche-google-network//regional?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
+  source = "github.com/osinfra-io/pt-arche-google-network//regional?ref=a27322fd1ee0c4dc11cbfe34d3266a99ff8f075f" # v0.3.7
 
   for_each                 = local.regional_subnets
   ip_cidr_range            = each.value.master_ipv4_cidr_block
@@ -32,7 +32,7 @@ module "google_network_master_subnets" {
 }
 
 module "google_network_subnets" {
-  source = "github.com/osinfra-io/pt-arche-google-network//regional?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
+  source = "github.com/osinfra-io/pt-arche-google-network//regional?ref=a27322fd1ee0c4dc11cbfe34d3266a99ff8f075f" # v0.3.7
 
   for_each                 = local.regional_subnets
   ip_cidr_range            = each.value.ip_cidr_range
@@ -54,7 +54,7 @@ module "google_network_subnets" {
 }
 
 module "google_network_cloud_nat" {
-  source = "github.com/osinfra-io/pt-arche-google-network//regional/nat?ref=ba20bee164e911915abc3b0f1145993f29199cb2" # v0.3.6
+  source = "github.com/osinfra-io/pt-arche-google-network//regional/nat?ref=a27322fd1ee0c4dc11cbfe34d3266a99ff8f075f" # v0.3.7
 
   depends_on = [
     module.google_network_subnets


### PR DESCRIPTION
Bumps arche module SHA pins to their latest releases:

- pt-arche-core-helpers: v0.3.2
- pt-arche-datadog-google-integration: v0.4.7
- pt-arche-google-cloud-sql: v0.2.8
- pt-arche-google-network: v0.3.7
- pt-arche-google-project: v0.7.5
- pt-arche-google-storage-bucket: v0.3.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated infrastructure components supporting monitoring integrations, networking, DNS, projects, storage, databases, and regional services.
  - Improved consistency across shared and regional infrastructure configurations.
  - No changes to configured resources, inputs, or deployment behavior were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->