### PR TITLE
Provision private DNS for platform-managed Cloud SQL

### DIFF
--- a/outputs.tofu
+++ b/outputs.tofu
@@ -21,6 +21,14 @@ output "osinfra_io_dns_zone" {
   value       = module.google_network_osinfra_io_dns
 }
 
+output "private_dns_zone" {
+  description = "The environment private DNS zone, for regional deployments to create records against"
+  value = {
+    dns_name = local.private_dns_zone_name
+    name     = local.private_dns_name
+  }
+}
+
 output "project_id" {
   description = "The project ID"
   value       = module.google_project.id

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -106,3 +106,17 @@ resource "google_compute_subnetwork_iam_member" "container_engine_master" {
   role       = "roles/compute.networkUser"
   subnetwork = module.google_network_master_subnets[each.key].name
 }
+
+# DNS Record Set Resource
+# https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/dns_record_set
+
+resource "google_dns_record_set" "cloud_sql" {
+  for_each = local.teams_with_cloud_sql_in_region
+
+  managed_zone = local.main.private_dns_zone.name
+  name         = "${each.key}-cloud-sql.${local.main.private_dns_zone.dns_name}"
+  project      = local.main.project_id
+  rrdatas      = [module.google_cloud_sql[each.key].private_ip_address]
+  ttl          = 300
+  type         = "A"
+}

--- a/regional/outputs.tofu
+++ b/regional/outputs.tofu
@@ -6,6 +6,7 @@ output "cloud_sql_instances" {
   value = {
     for team_key, sql in module.google_cloud_sql :
     team_key => {
+      host_fqdn          = trimsuffix(google_dns_record_set.cloud_sql[team_key].name, ".")
       instance           = sql.instance
       private_ip_address = sql.private_ip_address
     }


### PR DESCRIPTION
Teams that declare `cloud_sql` in Logos now also receive a **private DNS A record** (`team-cloud-sql`) in the environment private zone pointing at the Cloud SQL instance private IP, giving consumers a stable hostname without reading corpus regional state.

The main workspace now outputs the private DNS zone so the regional workspace can create the record.

This supports pt-pneuma dogfooding the platform-managed Cloud SQL for Authentik (pt-pneuma#142) and, together with the Logos `cloud_sql` declaration, fixes `SERVICE_NETWORKING_NOT_ENABLED` (the networking APIs are enabled on the project once a team declares `cloud_sql`).

Pneuma discovers the instance in its own project via a data source (no arche module change needed) and connects over this DNS name.

Depends on pt-logos#203 (the pt-pneuma `cloud_sql` declaration).

Note: the tofu-scan pre-commit finding on service accounts in `main.tofu` is pre-existing and unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added private DNS zone details to deployment outputs.
  * Automatically creates private DNS records for regional Cloud SQL instances.
  * Cloud SQL instance outputs now include a host fully qualified domain name (FQDN) for easier connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->