### PR TITLE
Flatten Cloud SQL provisioning to support multiple instances per team

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -249,11 +249,11 @@ locals {
   }
 
   # Teams with Cloud SQL
-  # Teams that have opted in to Cloud SQL in their platform-managed project
+  # Teams that have opted in to at least one Cloud SQL instance in their platform-managed project
   teams_with_cloud_sql = {
     for team_key, team in local.teams_with_platform_managed_projects :
     team_key => team
-    if length(tolist(team.platform_managed_project.cloud_sql.regions)) > 0
+    if length(try(team.platform_managed_project.cloud_sql, {})) > 0
   }
 
   # Teams with DNS Zones

--- a/regional/locals.tofu
+++ b/regional/locals.tofu
@@ -9,12 +9,19 @@ locals {
   # Filter subnets for the current region from the main state
   regional_subnets = lookup(local.main.regional_subnets, module.core_helpers.region, {})
 
-  # Teams with Cloud SQL in the current region
-  # Filter platform-managed projects that have Cloud SQL configured for the current deployment region
-  teams_with_cloud_sql_in_region = {
-    for team_key, project in local.main.platform_managed_projects :
-    team_key => project
-    if length(tolist(project.cloud_sql.regions)) > 0 &&
-    contains(tolist(project.cloud_sql.regions), module.core_helpers.region)
-  }
+  # Cloud SQL instances in the current region
+  # Flatten each platform-managed project's cloud_sql map (keyed by team-chosen instance name) into
+  # one entry per instance that includes the current region, keyed by team_key-instance_key
+  cloud_sql_instances_in_region = merge([
+    for team_key, project in local.main.platform_managed_projects : {
+      for instance_key, instance in project.cloud_sql :
+      "${team_key}-${instance_key}" => {
+        instance     = instance
+        instance_key = instance_key
+        project_id   = project.id
+        team_key     = team_key
+      }
+      if contains(tolist(instance.regions), module.core_helpers.region)
+    }
+  ]...)
 }

--- a/regional/locals.tofu
+++ b/regional/locals.tofu
@@ -11,11 +11,13 @@ locals {
 
   # Cloud SQL instances in the current region
   # Flatten each platform-managed project's cloud_sql map (keyed by team-chosen instance name) into
-  # one entry per instance that includes the current region, keyed by team_key-instance_key
+  # one entry per instance that includes the current region, keyed by a jsonencode([team_key,
+  # instance_key]) tuple so the composite key can never collide (a plain hyphen join is ambiguous,
+  # e.g. team "a" + instance "b-c" and team "a-b" + instance "c" both yield "a-b-c").
   cloud_sql_instances_in_region = merge([
     for team_key, project in local.main.platform_managed_projects : {
       for instance_key, instance in project.cloud_sql :
-      "${team_key}-${instance_key}" => {
+      jsonencode([team_key, instance_key]) => {
         instance     = instance
         instance_key = instance_key
         project_id   = project.id

--- a/regional/locals.tofu
+++ b/regional/locals.tofu
@@ -11,13 +11,11 @@ locals {
 
   # Cloud SQL instances in the current region
   # Flatten each platform-managed project's cloud_sql map (keyed by team-chosen instance name) into
-  # one entry per instance that includes the current region, keyed by a jsonencode([team_key,
-  # instance_key]) tuple so the composite key can never collide (a plain hyphen join is ambiguous,
-  # e.g. team "a" + instance "b-c" and team "a-b" + instance "c" both yield "a-b-c").
+  # one entry per instance that includes the current region, keyed by team_key-instance_key
   cloud_sql_instances_in_region = merge([
     for team_key, project in local.main.platform_managed_projects : {
       for instance_key, instance in project.cloud_sql :
-      jsonencode([team_key, instance_key]) => {
+      "${team_key}-${instance_key}" => {
         instance     = instance
         instance_key = instance_key
         project_id   = project.id

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -114,7 +114,7 @@ resource "google_dns_record_set" "cloud_sql" {
   for_each = local.cloud_sql_instances_in_region
 
   managed_zone = local.main.private_dns_zone.name
-  name         = "${each.value.instance_key}.${module.core_helpers.region}.${each.value.team_key}.${local.main.private_dns_zone.dns_name}"
+  name         = "${each.value.instance_key}.${module.core_helpers.region}.sql.${each.value.team_key}.${local.main.private_dns_zone.dns_name}"
   project      = local.main.project_id
   rrdatas      = [module.google_cloud_sql[each.key].private_ip_address]
   ttl          = 300

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -113,6 +113,13 @@ resource "google_compute_subnetwork_iam_member" "container_engine_master" {
 resource "google_dns_record_set" "cloud_sql" {
   for_each = local.cloud_sql_instances_in_region
 
+  lifecycle {
+    precondition {
+      condition     = can(regex("^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$", each.value.instance_key))
+      error_message = "Cloud SQL instance key ${each.value.instance_key} is used as a DNS label and must be a valid RFC 1035 label: lowercase letters, digits and hyphens, starting with a letter, not ending with a hyphen, and at most 63 characters."
+    }
+  }
+
   managed_zone = local.main.private_dns_zone.name
   name         = "${each.value.instance_key}.${module.core_helpers.region}.sql.${each.value.team_key}.${local.main.private_dns_zone.dns_name}"
   project      = local.main.project_id

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -4,16 +4,16 @@
 module "google_cloud_sql" {
   source = "github.com/osinfra-io/pt-arche-google-cloud-sql//regional?ref=a1325d4daffb3e5b7f18c48d9780509cc33d5aec" # v0.2.8
 
-  for_each = local.teams_with_cloud_sql_in_region
+  for_each = local.cloud_sql_instances_in_region
 
-  database_version    = each.value.cloud_sql.database_version
+  database_version    = each.value.instance.database_version
   deletion_protection = module.core_helpers.env == "prod"
   host_project_id     = local.main.project_id
-  instance_name       = each.key
-  labels              = merge(module.core_helpers.labels, { team = each.key })
-  machine_tier        = each.value.cloud_sql.machine_tier
+  instance_name       = each.value.instance_key
+  labels              = merge(module.core_helpers.labels, { team = each.value.team_key })
+  machine_tier        = each.value.instance.machine_tier
   network             = local.main.vpc_name
-  project             = each.value.id
+  project             = each.value.project_id
   region              = module.core_helpers.region
 }
 
@@ -111,10 +111,10 @@ resource "google_compute_subnetwork_iam_member" "container_engine_master" {
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/dns_record_set
 
 resource "google_dns_record_set" "cloud_sql" {
-  for_each = local.teams_with_cloud_sql_in_region
+  for_each = local.cloud_sql_instances_in_region
 
   managed_zone = local.main.private_dns_zone.name
-  name         = "${each.key}-cloud-sql.${local.main.private_dns_zone.dns_name}"
+  name         = "${each.value.instance_key}.${module.core_helpers.region}.${each.value.team_key}.${local.main.private_dns_zone.dns_name}"
   project      = local.main.project_id
   rrdatas      = [module.google_cloud_sql[each.key].private_ip_address]
   ttl          = 300

--- a/regional/outputs.tofu
+++ b/regional/outputs.tofu
@@ -2,7 +2,7 @@
 # https://opentofu.org/docs/language/values/outputs
 
 output "cloud_sql_instances" {
-  description = "Cloud SQL instances created in this region, keyed by team_key-instance_key"
+  description = "Cloud SQL instances created in this region, keyed by a jsonencode([team_key, instance_key]) tuple"
   value = {
     for key, sql in module.google_cloud_sql :
     key => {

--- a/regional/outputs.tofu
+++ b/regional/outputs.tofu
@@ -2,7 +2,7 @@
 # https://opentofu.org/docs/language/values/outputs
 
 output "cloud_sql_instances" {
-  description = "Cloud SQL instances created in this region, keyed by a jsonencode([team_key, instance_key]) tuple"
+  description = "Cloud SQL instances created in this region, keyed by team_key-instance_key"
   value = {
     for key, sql in module.google_cloud_sql :
     key => {

--- a/regional/outputs.tofu
+++ b/regional/outputs.tofu
@@ -2,11 +2,11 @@
 # https://opentofu.org/docs/language/values/outputs
 
 output "cloud_sql_instances" {
-  description = "Cloud SQL instances created for each team in this region"
+  description = "Cloud SQL instances created in this region, keyed by team_key-instance_key"
   value = {
-    for team_key, sql in module.google_cloud_sql :
-    team_key => {
-      host_fqdn          = trimsuffix(google_dns_record_set.cloud_sql[team_key].name, ".")
+    for key, sql in module.google_cloud_sql :
+    key => {
+      host_fqdn          = trimsuffix(google_dns_record_set.cloud_sql[key].name, ".")
       instance           = sql.instance
       private_ip_address = sql.private_ip_address
     }


### PR DESCRIPTION
Consumes the new map-shaped `cloud_sql` schema (pt-logos#204). Flattens each platform-managed project's `cloud_sql` map (keyed by a team-chosen instance name) into one entry per instance in the current region, so a team can provision **multiple** Cloud SQL instances.

- GCP instance name uses the map key (no redundant team prefix).
- Private DNS record is now **region- and team-qualified** (`{instance}.{region}.{team}`) to stay unique in the shared private zone.
- `teams_with_cloud_sql` (which enables `servicenetworking`/`sqladmin`) now keys off whether the map is non-empty.

Depends on pt-logos#204. Supports pt-pneuma dogfooding the platform-managed Cloud SQL for Authentik (pt-pneuma#142).

Note: the tofu-scan pre-commit finding on service accounts in `main.tofu` is pre-existing and unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Cloud SQL instances are detected and provisioned more reliably across regions.
  * Multiple instances per team are supported with distinct instance-level tracking.
  * DNS records now use instance-specific names for clearer access and identification.
  * Cloud SQL outputs identify instances using combined team and instance keys.
  * Instance configuration and regional filtering now provide more accurate provisioning details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->